### PR TITLE
remove warning check for astropy votable

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -72,3 +72,33 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
           file: ./coverage.xml #optional
+
+  pyuvsim:
+    name: pyuvsim
+    runs-on: ubuntu-latest
+    env:
+      ENV_NAME: pyuvsim
+      PYTHON: 3.7
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+         fetch-depth: 1
+      - name: Get Miniconda Linux
+        run: |
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh;
+          bash $HOME/miniconda.sh -b -p $HOME/miniconda
+      - name: Setup Environment
+        run: |
+          export PATH="$HOME/miniconda/bin:$PATH"
+          ./ci/install_conda.sh
+
+      - bash: |
+          source activate ${ENV_NAME}
+          pip install --no-deps .
+          cd ../
+          git clone https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
+          cd pyuvsim
+          mkdir test-reports
+          python -m pytest pyuvsim --junitxml=test-reports/xunit.xml
+        displayName: run pyuvsim tests

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -94,6 +94,7 @@ jobs:
           ./ci/install_conda.sh
       - name: run pyuvsim tests
         run: |
+          export PATH="$HOME/miniconda/bin:$PATH"
           source activate $ENV_NAME
           pip install --no-deps .
           cd ../

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -94,7 +94,7 @@ jobs:
           ./ci/install_conda.sh
       - name: run pyuvsim tests
         run: |
-          source activate ${ENV_NAME}
+          source activate $ENV_NAME
           pip install --no-deps .
           cd ../
           git clone https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -31,7 +31,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       OS: ${{ matrix.os }}
     name: Testing
-    needs: [linter]
+    #    needs: [linter]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -92,8 +92,8 @@ jobs:
         run: |
           export PATH="$HOME/miniconda/bin:$PATH"
           ./ci/install_conda.sh
-
-      - bash: |
+      - name: run pyuvsim tests
+        run: |
           source activate ${ENV_NAME}
           pip install --no-deps .
           cd ../
@@ -101,4 +101,3 @@ jobs:
           cd pyuvsim
           mkdir test-reports
           python -m pytest pyuvsim --junitxml=test-reports/xunit.xml
-        displayName: run pyuvsim tests

--- a/ci/pyuvsim.yaml
+++ b/ci/pyuvsim.yaml
@@ -1,0 +1,18 @@
+name: pyuvsim
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - astropy
+  - astropy-healpix
+  - h5py
+  - line_profiler
+  - numpy
+  - mpi4py>=3.0.0
+  - psutil
+  - pytest
+  - pytest-runner
+  - pyuvdata
+  - pyyaml
+  - scipy
+  - setuptools_scm

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -6,6 +6,7 @@ dependencies:
   - astropy
   - astropy-healpix
   - numpy
+  - h5py
   - pyyaml
   - scipy
   - coverage

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -12,3 +12,4 @@ dependencies:
   - coverage
   - pytest-cov
   - setuptools_scm
+  - pyuvdata

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - pyyaml
   - scipy
+  - h5py
   - coverage
   - pytest-cov
   - setuptools_scm

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -62,7 +62,7 @@ class SkyModel(object):
             - 'spectral_index' : Flux is given at a reference frequency. (TODO)
     rise_lst : array_like of float
         Approximate lst (radians) when the source rises, shape (Ncomponents,).
-        Set by coarse horizon cut in simsetup.
+        Set by source_cuts.
         Default is nan, meaning the source never rises.
     set_lst : array_like of float
         Approximate lst (radians) when the source sets, shape (Ncomponents,).
@@ -537,7 +537,7 @@ def source_cuts(catalog_table, latitude_deg=None, horizon_buffer=0.04364,
 def read_votable_catalog(gleam_votable, source_select_kwds={},
                          return_table=False):
     """
-    Creates a list of pyuvsim source objects from a votable catalog.
+    Creates a SkyModel object from a votable catalog.
 
     Tested on: GLEAM EGC catalog, version 2
 
@@ -559,7 +559,7 @@ def read_votable_catalog(gleam_votable, source_select_kwds={},
             * `max_flux`: Maximum stokes I flux to select [Jy]
 
     Returns:
-        if return_table, recarray of source parameters, otherwise :class:`pyuvsim.SkyModel` instance
+        if return_table, recarray of source parameters, otherwise :class:`pyradiosky.SkyModel` instance
     """
 
     class Found(Exception):
@@ -623,7 +623,7 @@ def read_text_catalog(catalog_csv, source_select_kwds={}, return_table=False):
             * `max_flux`: Maximum stokes I flux to select [Jy]
 
     Returns:
-        :class:`pyuvsim.SkyModel`
+        :class:`pyradiosky.SkyModel`
     """
     with open(catalog_csv, 'r') as cfile:
         header = cfile.readline()
@@ -648,11 +648,11 @@ def read_text_catalog(catalog_csv, source_select_kwds={}, return_table=False):
 
 def write_catalog_to_file(filename, catalog):
     """
-    Writes out a catalog to a text file, readable with simsetup.read_catalog_text()
+    Writes out a catalog to a text file, readable with skymodel.read_catalog_text()
 
     Args:
         filename: Path to output file (string)
-        catalog: pyuvsim.SkyModel object
+        catalog: pyradiosky.SkyModel object
     """
     with open(filename, 'w+') as fo:
         fo.write("SOURCE_ID\tRA_J2000 [deg]\tDec_J2000 [deg]\tFlux [Jy]\tFrequency [Hz]\n")

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -662,5 +662,3 @@ def write_catalog_to_file(filename, catalog):
 
             fo.write("{}\t{:f}\t{:f}\t{:0.2f}\t{:0.2f}\n".format(
                 srcid, ra, dec, flux_i[0], freq[0]))
-
-

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -12,8 +12,9 @@ def r_hat(theta, phi):
     Parameters
     ----------
     theta, phi : float
-        The theta, phi coordinates for the point on the sphere (using normal
-        mathematical conventions)
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
 
     Returns
     -------
@@ -37,8 +38,9 @@ def theta_hat(theta, phi):
     Parameters
     ----------
     theta, phi : float
-        The theta, phi coordinates for the point on the sphere (using normal
-        mathematical conventions)
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
 
     Returns
     -------
@@ -62,8 +64,9 @@ def phi_hat(theta, phi):
     Parameters
     ----------
     theta, phi : float
-        The theta, phi coordinates for the point on the sphere (using normal
-        mathematical conventions)
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
 
     Returns
     -------
@@ -96,8 +99,9 @@ def rotate_points_3d(rot_matrix, theta, phi):
     rot_matrix : array-like of float
         rotation matrix to use
     theta, phi : float
-        The theta, phi coordinates for the point on the sphere (using normal
-        mathematical conventions) in the inital frame.
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
 
     Returns
     -------
@@ -147,8 +151,9 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rot_matrix, beta=None,
     Parameters
     ----------
     theta, phi : float
-        The theta, phi coordinates for the point on the sphere (using normal
-        mathematical conventions) in the inital frame.
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
     rot_matrix : array-like of float
         Rotation matrix that takes 3-vectors from (theta, phi) to (beta, alpha)
     beta, alpha : float, optional
@@ -253,8 +258,10 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
     r1, r2 : array-like of float, optional
         length 3 unit vectors
     theta1, phi1, theta2, phi2 : float, optional
-        The theta, phi coordinates for the two point on the sphere (using normal
-        mathematical conventions). Ignored if r1 and r2 are supplied.
+        The co-latitude and azimuth coordinates, respectively, for a point
+        on the sphere, in radians. Azimuth is defined with respect to the
+        x axis, co-latitude is the angle with the positive z axis.
+        Ignored if r1 and r2 are supplied.
 
     Returns
     -------

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -195,7 +195,7 @@ def axis_angle_rotation_matrix(axis, angle):
     """
     if axis.shape != (3,):
         raise ValueError('axis must be a must be length 3 vector')
-    if not verify_is_unit_vector(axis):
+    if not is_unit_vector(axis):
         raise ValueError('axis must be a unit vector')
 
     K_matrix = np.array([[0., -axis[2], axis[1]],
@@ -210,7 +210,7 @@ def axis_angle_rotation_matrix(axis, angle):
     return rot_matrix
 
 
-def verify_is_orthogonal(matrix, tol=1e-15):
+def is_orthogonal(matrix, tol=1e-15):
     """
     Test for matrix orthogonality.
 
@@ -227,7 +227,7 @@ def verify_is_orthogonal(matrix, tol=1e-15):
     return np.allclose(np.matmul(matrix, matrix.T), np.eye(3), atol=tol)
 
 
-def verify_is_unit_vector(vec, tol=1e-15):
+def is_unit_vector(vec, tol=1e-15):
     """
     Test for unit vectors.
 
@@ -268,14 +268,14 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
         r1 = r_hat(theta1, phi1)
         r2 = r_hat(theta2, phi2)
 
-        assert verify_is_unit_vector(r1), 'r1 is not a unit vector: ' + str(r1)
-        assert verify_is_unit_vector(r2), 'r2 is not a unit vector: ' + str(r2)
+        assert is_unit_vector(r1), 'r1 is not a unit vector: ' + str(r1)
+        assert is_unit_vector(r2), 'r2 is not a unit vector: ' + str(r2)
     else:
         r1 = np.array(r1)
         r2 = np.array(r2)
         if r1.shape != (3,) or r2.shape != (3,):
             raise ValueError('r1 and r2 must be length 3 vectors')
-        if not verify_is_unit_vector(r1) or not verify_is_unit_vector(r2):
+        if not is_unit_vector(r1) or not is_unit_vector(r2):
             raise ValueError('r1 and r2 must be unit vectors')
 
     norm = np.cross(r1, r2)
@@ -286,7 +286,7 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
     Psi = np.arctan2(sinPsi, cosPsi)
     rotation = axis_angle_rotation_matrix(n_hat, Psi)
 
-    assert verify_is_unit_vector(n_hat), 'n_hat is not a unit vector: ' + str(n_hat)
-    assert verify_is_orthogonal(rotation), ('rotation matrix is not orthogonal: '
+    assert is_unit_vector(n_hat), 'n_hat is not a unit vector: ' + str(n_hat)
+    assert is_orthogonal(rotation), ('rotation matrix is not orthogonal: '
                                             + str(rotation))
     return rotation

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -80,7 +80,7 @@ def phi_hat(theta, phi):
     return np.stack((phx, phy, phz))
 
 
-def spherical_coordinates_map(rot_matrix, theta, phi):
+def rotate_points_3d(rot_matrix, theta, phi):
     """
     Get the spherical coordinates of the point under a 3d rotation.
 
@@ -154,7 +154,7 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rot_matrix, beta=None,
     beta, alpha : float, optional
         The theta, phi coordinates for the point on the sphere (using normal
         mathematical conventions) in the rotated frame. If either is not provided,
-        they are calculated using `spherical_coordinates_map`. Note these may
+        they are calculated using `rotate_points_3d`. Note these may
         not be as exact as values calculated from astropy.
 
     Returns
@@ -164,7 +164,7 @@ def spherical_basis_vector_rotation_matrix(theta, phi, rot_matrix, beta=None,
         the beta/alpha basis.
     """
     if alpha is None or beta is None:
-        beta, alpha = spherical_coordinates_map(rot_matrix, theta, phi)
+        beta, alpha = rotate_points_3d(rot_matrix, theta, phi)
 
     th = theta_hat(theta, phi)
     ph = phi_hat(theta, phi)

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -421,6 +421,7 @@ def test_healpix_positions():
     assert np.isclose(src_lmn[1][ipix], src_m)
     assert np.isclose(src_lmn[2][ipix], src_n)
 
+
 def test_param_flux_cuts():
     # Check that min/max flux limits in test params work.
 
@@ -490,6 +491,7 @@ def test_flux_cuts():
     )
     assert np.all(cut_sourcelist['flux_density_I'] > minI_cut)
     assert np.all(cut_sourcelist['flux_density_I'] < maxI_cut)
+
 
 def test_circumpolar_nonrising():
     # Check that the source_cut function correctly identifies sources that are circumpolar or

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -424,12 +424,7 @@ def test_healpix_positions():
 def test_param_flux_cuts():
     # Check that min/max flux limits in test params work.
 
-    catalog_table = uvtest.checkWarnings(
-        read_votable_catalog, func_args=[GLEAM_vot],
-        func_kwargs={'return_table': True}, message=GLEAM_vot, nwarnings=11,
-        category=([astropy.io.votable.exceptions.W27]
-                  + [astropy.io.votable.exceptions.W50] * 10)
-    )
+    catalog_table = read_votable_catalog(GLEAM_vot, return_table=True)
 
     catalog_table = source_cuts(catalog_table, min_flux=0.2, max_flux=1.5)
 
@@ -538,22 +533,15 @@ def test_circumpolar_nonrising():
 
 
 def test_read_gleam():
-    sourcelist = uvtest.checkWarnings(
-        read_votable_catalog, [GLEAM_vot],
-        message=GLEAM_vot, nwarnings=11,
-        category=[astropy.io.votable.exceptions.W27] + [astropy.io.votable.exceptions.W50] * 10
-    )
+    sourcelist = read_votable_catalog(GLEAM_vot)
 
     assert sourcelist.Ncomponents == 50
 
     # Check cuts
     source_select_kwds = {'min_flux': 1.0}
-    catalog = uvtest.checkWarnings(
-        read_votable_catalog, [GLEAM_vot],
-        dict(source_select_kwds=source_select_kwds, return_table=True),
-        message=GLEAM_vot, nwarnings=11,
-        category=[astropy.io.votable.exceptions.W27] + [astropy.io.votable.exceptions.W50] * 10
-    )
+    catalog = read_votable_catalog(GLEAM_vot,
+                                   source_select_kwds=source_select_kwds,
+                                   return_table=True)
 
     assert len(catalog) < sourcelist.Ncomponents
 
@@ -584,11 +572,7 @@ def test_catalog_file_writer():
 
 
 def test_array_to_skymodel_loop():
-    sky = uvtest.checkWarnings(
-        read_votable_catalog, [GLEAM_vot],
-        message=GLEAM_vot, nwarnings=11,
-        category=[astropy.io.votable.exceptions.W27] + [astropy.io.votable.exceptions.W50] * 10
-    )
+    sky = read_votable_catalog(GLEAM_vot)
     sky.ra = Angle(sky.ra.rad, 'rad')
     sky.dec = Angle(sky.dec.rad, 'rad')
     arr = skymodel_to_array(sky)

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -29,7 +29,7 @@ def test_source_zenith_from_icrs():
     lst = time.sidereal_time('apparent')
 
     tee_ra = lst
-    cirs_ra = skyutils.tee_to_cirs_ra(tee_ra, time)
+    cirs_ra = skyutils._tee_to_cirs_ra(tee_ra, time)
 
     cirs_source_coord = SkyCoord(ra=cirs_ra, dec=array_location.lat,
                                  obstime=time, frame='cirs', location=array_location)

--- a/pyradiosky/tests/test_spherical_coords_transforms.py
+++ b/pyradiosky/tests/test_spherical_coords_transforms.py
@@ -21,7 +21,7 @@ def test_hat_errors(func_name):
 
 
 @pytest.mark.skip()
-def test_spherical_coordinates_map():
+def test_rotate_points_3d():
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
     time0 = Time('2018-03-01 18:00:00', scale='utc', location=array_location)
 
@@ -91,7 +91,7 @@ def test_spherical_coordinates_map():
 
         R_perturb = sct.vecs2rot(r1=intermediate_vec, r2=altaz_vec)
 
-        intermediate_theta, intermediate_phi = sct.spherical_coordinates_map(
+        intermediate_theta, intermediate_phi = sct.rotate_points_3d(
             R_avg, theta_radec, phi_radec)
         R_perturb_pts = sct.vecs2rot(theta1=intermediate_theta, phi1=intermediate_phi,
                                      theta2=theta_altaz, phi2=phi_altaz)
@@ -100,7 +100,7 @@ def test_spherical_coordinates_map():
 
         R_exact = np.matmul(R_perturb, R_avg)
 
-        calc_theta_altaz, calc_phi_altaz = sct.spherical_coordinates_map(
+        calc_theta_altaz, calc_phi_altaz = sct.rotate_points_3d(
             R_exact, theta_radec, phi_radec)
 
         if ti == zero_indx:
@@ -133,7 +133,7 @@ def test_spherical_coordinates_map():
 
     # check errors are raised appropriately
     with pytest.raises(ValueError) as cm:
-        sct.spherical_coordinates_map(R_exact[0:1, :], theta_radec, phi_radec)
+        sct.rotate_points_3d(R_exact[0:1, :], theta_radec, phi_radec)
     assert str(cm.value).startswith('rot_matrix must be a 3x3 array')
 
     with pytest.raises(ValueError) as cm:

--- a/pyradiosky/tests/test_utils.py
+++ b/pyradiosky/tests/test_utils.py
@@ -13,8 +13,8 @@ import pyradiosky.utils as skyutils
 def test_tee_ra_loop():
     time = Time(2457458.1739, scale='utc', format='jd')
     tee_ra = Angle(np.pi / 4., unit='rad')  # rad
-    cirs_ra = skyutils.tee_to_cirs_ra(tee_ra, time)
-    new_tee_ra = skyutils.cirs_to_tee_ra(cirs_ra, time)
+    cirs_ra = skyutils._tee_to_cirs_ra(tee_ra, time)
+    new_tee_ra = skyutils._cirs_to_tee_ra(cirs_ra, time)
     assert new_tee_ra == tee_ra
 
 

--- a/pyradiosky/utils.py
+++ b/pyradiosky/utils.py
@@ -15,7 +15,7 @@ from astropy.coordinates import Angle
 # astropy doesn't have this frame but it's pretty easy to adapt the CIRS frame
 # by modifying the ra to reflect the difference between
 # GAST (Grenwich Apparent Sidereal Time) and the earth rotation angle (theta)
-def tee_to_cirs_ra(tee_ra, time):
+def _tee_to_cirs_ra(tee_ra, time):
     era = erfa.era00(*get_jd12(time, 'ut1'))
     theta_earth = Angle(era, unit='rad')
 
@@ -26,7 +26,7 @@ def tee_to_cirs_ra(tee_ra, time):
     return cirs_ra
 
 
-def cirs_to_tee_ra(cirs_ra, time):
+def _cirs_to_tee_ra(cirs_ra, time):
     era = erfa.era00(*get_jd12(time, 'ut1'))
     theta_earth = Angle(era, unit='rad')
 
@@ -39,7 +39,7 @@ def cirs_to_tee_ra(cirs_ra, time):
 
 def stokes_to_coherency(stokes_vector):
     """
-    Convert Stokes vector to coherency matrix
+    Convert Stokes vector to coherency matrix.
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2019 Radio Astronomy Software Group
 # Licensed under the 2-clause BSD License
 
-from __future__ import absolute_import, division, print_function
-
 import glob
 import io
 import sys

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,9 @@
 from __future__ import absolute_import, division, print_function
 
 import glob
-import os
 import io
 import sys
 from setuptools import setup
-import json
 
 sys.path.append('pyradiosky')
 # import version  # noqa
@@ -19,6 +17,7 @@ sys.path.append('pyradiosky')
 #     json.dump(data, outfile)
 class mock_version(object):
     version = 0.0
+
 
 version = mock_version()
 


### PR DESCRIPTION
Tests fail because astropy no longer warns about Jy/beam unit in VOTable read.

closes #32
closes #31
closes #30
closes #28
closes #27
closes #14