### PR TITLE
Pre commit

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -24,7 +24,8 @@ jobs:
         run: |
           export PATH="$HOME/miniconda/bin:$PATH"
           source activate ${ENV_NAME}
-          flake8
+          pre-commit install
+          pre-commit run -a
   tests:
     env:
       ENV_NAME: tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,14 @@ repos:
           - id: flake8
             additional_dependencies:
                 - flake8-docstrings
+                - flake8-rst-docstrings
                 - flake8-comprehensions
                 - flake8-black
-#                - flake8-builtins
+                - flake8-builtins
 #                - flake8-eradicate
 #                - pep8-naming
 #                - flake8-isort
-#                - flake8-rst-docstrings
+
 #                - flake8-copyright
 
     - repo: https://github.com/psf/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+exclude: '(^docs/conf.py|^user_data/External_tables/*)'
+
+repos:
+    - repo: git://github.com/pre-commit/pre-commit-hooks
+      rev: v2.4.0
+      hooks:
+          - id: trailing-whitespace
+          - id: check-added-large-files
+          - id: check-ast
+          - id: check-json
+          - id: check-merge-conflict
+          - id: check-xml
+          - id: check-yaml
+          - id: debug-statements
+          - id: end-of-file-fixer
+          - id: mixed-line-ending
+            args: ['--fix=no']
+          - id: flake8
+            additional_dependencies:
+                - flake8-docstrings
+#                - flake8-comprehensions
+#                - flake8-black
+#                - flake8-builtins
+#                - flake8-eradicate
+#                - pep8-naming
+#                - flake8-isort
+#                - flake8-rst-docstrings
+#                - flake8-copyright
+
+#    - repo: https://github.com/psf/black
+#      rev: 19.10b0
+#      hooks:
+#          - id: black
+#    - repo: https://github.com/pre-commit/mirrors-isort
+#      rev: v4.3.21
+#      hooks:
+#      - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,11 @@ repos:
                 - flake8-comprehensions
                 - flake8-black
                 - flake8-builtins
-#                - flake8-eradicate
+                - flake8-copyright
 #                - pep8-naming
+#                - flake8-eradicate
 #                - flake8-isort
 
-#                - flake8-copyright
 
     - repo: https://github.com/psf/black
       rev: 19.10b0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
                 - flake8-black
                 - flake8-builtins
                 - flake8-copyright
-#                - pep8-naming
+                - pep8-naming
 #                - flake8-eradicate
 #                - flake8-isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
           - id: flake8
             additional_dependencies:
                 - flake8-docstrings
-#                - flake8-comprehensions
+                - flake8-comprehensions
 #                - flake8-black
 #                - flake8-builtins
 #                - flake8-eradicate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
             additional_dependencies:
                 - flake8-docstrings
                 - flake8-comprehensions
-#                - flake8-black
+                - flake8-black
 #                - flake8-builtins
 #                - flake8-eradicate
 #                - pep8-naming
@@ -27,10 +27,10 @@ repos:
 #                - flake8-rst-docstrings
 #                - flake8-copyright
 
-#    - repo: https://github.com/psf/black
-#      rev: 19.10b0
-#      hooks:
-#          - id: black
+    - repo: https://github.com/psf/black
+      rev: 19.10b0
+      hooks:
+          - id: black
 #    - repo: https://github.com/pre-commit/mirrors-isort
 #      rev: v4.3.21
 #      hooks:

--- a/ci/linting.yaml
+++ b/ci/linting.yaml
@@ -3,9 +3,4 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - flake8
-  - pip
-  - pip:
-      - flake8-docstrings
-      - flake8-pytest
-      - flake8-black
+  - pre-commit

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -520,7 +520,8 @@ def healpix_to_sky(hpmap, indices, freqs):
         import astropy_healpix
     except ImportError as e:
         raise ImportError(
-            'The astropy-healpix module must be installed to use HEALPix methods') from e
+            "The astropy-healpix module must be installed to use HEALPix methods"
+        ) from e
 
     Nside = astropy_healpix.npix_to_nside(hpmap.shape[-1])
     ra, dec = astropy_healpix.healpix_to_lonlat(indices, Nside)

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -454,9 +454,8 @@ class SkyModel(object):
         self.horizon_mask = self.alt_az[0, :] < 0.0
 
     def __eq__(self, other):
-        """Check for equality between SkyModel objects."""
+        """Test equality with another sky model."""
         time_check = self.time is None and other.time is None
-
         if not time_check:
             time_check = np.isclose(self.time, other.time)
         return (

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -86,18 +86,17 @@ class SkyModel(object):
         Reference frequencies of flux values, shape (Ncomponents,).
     spectral_type : str
         Indicates how fluxes should be calculated at each frequency.
-        Options :
-            - 'flat' : Flat spectrum.
-            - 'full' : Flux is defined by a saved value at each frequency.
-            - 'subband' : Flux is given at a set of band centers. (TODO)
-            - 'spectral_index' : Flux is given at a reference frequency. (TODO)
     spectral_index : array_like of float
         Spectral index of each source, shape (Nfreqs, Ncomponents).
         None if spectral_type is not 'spectral_index'.
+        Options:
+        - 'flat' : Flat spectrum.
+        - 'full' : Flux is defined by a saved value at each frequency.
+        - 'subband' : Flux is given at a set of band centers. (TODO)
+        - 'spectral_index' : Flux is given at a reference frequency. (TODO)
     rise_lst : array_like of float
-        Approximate lst (radians) when the source rises, shape (Ncomponents,).
-        Set by source_cuts.
-        Default is nan, meaning the source never rises.
+        Approximate lst (radians) when the source rises, shape (Ncomponents,). Set by
+        coarse horizon cut in simsetup. Default is nan, meaning the source never rises.
     set_lst : array_like of float
         Approximate lst (radians) when the source sets, shape (Ncomponents,).
         Default is None, meaning the source never sets.

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -20,25 +20,27 @@ from . import spherical_coords_transforms as sct
 
 
 __all__ = [
-    'hasmoon',
-    'SkyModel',
-    'read_healpix_hdf5',
-    'healpix_to_sky',
-    'skymodel_to_array',
-    'array_to_skymodel',
-    'source_cuts',
-    'read_votable_catalog',
-    'read_text_catalog',
-    'read_idl_catalog',
-    'write_catalog_to_file'
+    "hasmoon",
+    "SkyModel",
+    "read_healpix_hdf5",
+    "healpix_to_sky",
+    "skymodel_to_array",
+    "array_to_skymodel",
+    "source_cuts",
+    "read_votable_catalog",
+    "read_text_catalog",
+    "read_idl_catalog",
+    "write_catalog_to_file",
 ]
 
 
 try:
     from lunarsky import SkyCoord, MoonLocation, LunarTopo
+
     hasmoon = True
 except ImportError:
     from astropy.coordinates import SkyCoord
+
     hasmoon = False
 
     class MoonLocation:
@@ -46,6 +48,7 @@ except ImportError:
 
     class LunarTopo:
         pass
+
 
 # Nov 5 2019 notes
 #    Read/write methods to add:
@@ -424,7 +427,7 @@ class SkyModel(object):
         if self.time == time:  # Don't repeat calculations
             return
 
-        skycoord_use = SkyCoord(self.ra, self.dec, frame='icrs')
+        skycoord_use = SkyCoord(self.ra, self.dec, frame="icrs")
         if isinstance(telescope_location, MoonLocation):
             source_altaz = skycoord_use.transform_to(
                 LunarTopo(obstime=time, location=telescope_location)

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -202,9 +202,9 @@ def axis_angle_rotation_matrix(axis, angle):
     """
     if axis.shape != (3,):
 
-        raise ValueError('axis must be a must be length 3 vector')
+        raise ValueError("axis must be a must be length 3 vector")
     if not is_unit_vector(axis):
-        raise ValueError('axis must be a unit vector')
+        raise ValueError("axis must be a unit vector")
 
     K_matrix = np.array(
         [[0.0, -axis[2], axis[1]], [axis[2], 0.0, -axis[0]], [-axis[1], axis[0], 0.0]]
@@ -283,16 +283,16 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
         r1 = r_hat(theta1, phi1)
         r2 = r_hat(theta2, phi2)
 
-        assert is_unit_vector(r1), 'r1 is not a unit vector: ' + str(r1)
-        assert is_unit_vector(r2), 'r2 is not a unit vector: ' + str(r2)
+        assert is_unit_vector(r1), "r1 is not a unit vector: " + str(r1)
+        assert is_unit_vector(r2), "r2 is not a unit vector: " + str(r2)
     else:
         r1 = np.array(r1)
         r2 = np.array(r2)
         if r1.shape != (3,) or r2.shape != (3,):
 
-            raise ValueError('r1 and r2 must be length 3 vectors')
+            raise ValueError("r1 and r2 must be length 3 vectors")
         if not is_unit_vector(r1) or not is_unit_vector(r2):
-            raise ValueError('r1 and r2 must be unit vectors')
+            raise ValueError("r1 and r2 must be unit vectors")
 
     norm = np.cross(r1, r2)
     # Note that Psi is between 0 and pi
@@ -302,8 +302,9 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
     Psi = np.arctan2(sinPsi, cosPsi)
     rotation = axis_angle_rotation_matrix(n_hat, Psi)
 
-    assert is_unit_vector(n_hat), 'n_hat is not a unit vector: ' + str(n_hat)
-    assert is_orthogonal(rotation), ('rotation matrix is not orthogonal: '
-                                            + str(rotation))
+    assert is_unit_vector(n_hat), "n_hat is not a unit vector: " + str(n_hat)
+    assert is_orthogonal(rotation), "rotation matrix is not orthogonal: " + str(
+        rotation
+    )
 
     return rotation

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -201,6 +201,7 @@ def axis_angle_rotation_matrix(axis, angle):
         3x3 rotation matrix to rotate vectors by `angle` around `axis`.
     """
     if axis.shape != (3,):
+
         raise ValueError('axis must be a must be length 3 vector')
     if not is_unit_vector(axis):
         raise ValueError('axis must be a unit vector')
@@ -288,6 +289,7 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
         r1 = np.array(r1)
         r2 = np.array(r2)
         if r1.shape != (3,) or r2.shape != (3,):
+
             raise ValueError('r1 and r2 must be length 3 vectors')
         if not is_unit_vector(r1) or not is_unit_vector(r2):
             raise ValueError('r1 and r2 must be unit vectors')
@@ -303,4 +305,5 @@ def vecs2rot(r1=None, r2=None, theta1=None, phi1=None, theta2=None, phi2=None):
     assert is_unit_vector(n_hat), 'n_hat is not a unit vector: ' + str(n_hat)
     assert is_orthogonal(rotation), ('rotation matrix is not orthogonal: '
                                             + str(rotation))
+
     return rotation

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -362,7 +362,7 @@ def test_polarized_source_smooth_visibilities():
 
 
 def test_read_healpix_hdf5():
-    pytest.importorskip('astropy_healpix')
+    pytest.importorskip("astropy_healpix")
     import astropy_healpix
 
     Nside = 32
@@ -482,7 +482,7 @@ def test_read_healpix_hdf5():
 
 def test_healpix_to_sky():
     hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-        os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+        os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
     )
 
     try:
@@ -490,8 +490,10 @@ def test_healpix_to_sky():
     except ImportError:
         with pytest.raises(ImportError) as cm:
             skymodel.healpix_to_sky(hpmap, inds, freqs)
-        assert str(cm.value).startswith("The astropy-healpix module must be installed to use HEALPix methods")
-        pytest.importorskip('astropy_healpix')
+        assert str(cm.value).startswith(
+            "The astropy-healpix module must be installed to use HEALPix methods"
+        )
+        pytest.importorskip("astropy_healpix")
 
     Nside = 32
     Npix = astropy_healpix.nside_to_npix(Nside)
@@ -599,7 +601,7 @@ def test_healpix_to_sky():
 
 
 def test_units_healpix_to_sky():
-    pytest.importorskip('astropy_healpix')
+    pytest.importorskip("astropy_healpix")
     import astropy_healpix
 
     Nside = 32
@@ -620,7 +622,7 @@ def test_units_healpix_to_sky():
 
 
 def test_healpix_positions():
-    pytest.importorskip('astropy_healpix')
+    pytest.importorskip("astropy_healpix")
     import astropy_healpix
 
     # write out a healpix file, read it back in check that it is as expected

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -825,6 +825,7 @@ def test_read_gleam():
 
     # Check cuts
     source_select_kwds = {'min_flux': 1.0}
+
     catalog = skymodel.read_votable_catalog(
         GLEAM_vot,
         source_select_kwds=source_select_kwds,

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -45,16 +45,18 @@ def test_source_zenith_from_icrs():
     dec = icrs_coord.dec
     # Check error cases
     with pytest.raises(ValueError) as cm:
-        skymodel.SkyModel('icrs_zen', ra.rad, dec.rad, [1, 0, 0, 0], 1e8, 'flat')
-    assert str(cm.value).startswith('ra must be an astropy Angle object. '
-                                    'value was: 3.14')
+        skymodel.SkyModel("icrs_zen", ra.rad, dec.rad, [1, 0, 0, 0], 1e8, "flat")
+    assert str(cm.value).startswith(
+        "ra must be an astropy Angle object. " "value was: 3.14"
+    )
 
     with pytest.raises(ValueError) as cm:
-        skymodel.SkyModel('icrs_zen', ra, dec.rad, [1, 0, 0, 0], 1e8, 'flat')
-    assert str(cm.value).startswith('dec must be an astropy Angle object. '
-                                    'value was: -0.53')
+        skymodel.SkyModel("icrs_zen", ra, dec.rad, [1, 0, 0, 0], 1e8, "flat")
+    assert str(cm.value).startswith(
+        "dec must be an astropy Angle object. " "value was: -0.53"
+    )
 
-    zenith_source = skymodel.SkyModel('icrs_zen', ra, dec, [1, 0, 0, 0], 1e8, 'flat')
+    zenith_source = skymodel.SkyModel("icrs_zen", ra, dec, [1, 0, 0, 0], 1e8, "flat")
 
     zenith_source.update_positions(time, array_location)
     zenith_source_lmn = zenith_source.pos_lmn.squeeze()
@@ -82,7 +84,7 @@ def test_source_zenith():
     names = "zen_source"
     stokes = [1, 0, 0, 0]
     freqs = [1e8]
-    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, 'flat')
+    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, "flat")
 
     zenith_source.update_positions(time, array_location)
     zenith_source_lmn = zenith_source.pos_lmn.squeeze()
@@ -95,12 +97,19 @@ def test_calc_basis_rotation_matrix():
     actually a rotation matrix (R R^T = R^T R = I)
     """
 
-    time = Time('2018-01-01 00:00')
+    time = Time("2018-01-01 00:00")
     telescope_location = EarthLocation(
-        lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
+        lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0
+    )
 
-    source = skymodel.SkyModel('Test', Angle(12. * units.hr),
-                               Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "Test",
+        Angle(12.0 * units.hr),
+        Angle(-30.0 * units.deg),
+        [1.0, 0.0, 0.0, 0.0],
+        1e8,
+        "flat",
+    )
 
     source.update_positions(time, telescope_location)
 
@@ -116,12 +125,19 @@ def test_calc_vector_rotation():
     I suppose we could also have checked (R R^T = R^T R = I)
     """
 
-    time = Time('2018-01-01 00:00')
+    time = Time("2018-01-01 00:00")
     telescope_location = EarthLocation(
-        lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
+        lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0
+    )
 
-    source = skymodel.SkyModel('Test', Angle(12. * units.hr),
-                               Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "Test",
+        Angle(12.0 * units.hr),
+        Angle(-30.0 * units.deg),
+        [1.0, 0.0, 0.0, 0.0],
+        1e8,
+        "flat",
+    )
 
     source.update_positions(time, telescope_location)
 
@@ -178,8 +194,14 @@ def test_polarized_source_visibilities():
     decoff = 0.0 * units.arcmin  # -0.17 * units.arcsec
     raoff = 0.0 * units.arcsec
 
-    source = skymodel.SkyModel('icrs_zen', zenith_icrs.ra + raoff,
-                               zenith_icrs.dec + decoff, stokes_radec, 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "icrs_zen",
+        zenith_icrs.ra + raoff,
+        zenith_icrs.dec + decoff,
+        stokes_radec,
+        1e8,
+        "flat",
+    )
 
     coherency_matrix_local = np.zeros([2, 2, ntimes], dtype="complex128")
     alts = np.zeros(ntimes)
@@ -291,8 +313,9 @@ def test_polarized_source_smooth_visibilities():
 
     stokes_radec = [1, -0.2, 0.3, 0.1]
 
-    source = skymodel.SkyModel('icrs_zen', zenith_icrs.ra,
-                               zenith_icrs.dec, stokes_radec, 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "icrs_zen", zenith_icrs.ra, zenith_icrs.dec, stokes_radec, 1e8, "flat"
+    )
 
     coherency_matrix_local = np.zeros([2, 2, ntimes], dtype="complex128")
     alts = np.zeros(ntimes)
@@ -449,7 +472,7 @@ def test_read_healpix_hdf5():
     frequencies = np.linspace(100, 110, 10)
 
     hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-        os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+        os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
     )
 
     assert np.allclose(hpmap[0, :], m)
@@ -584,10 +607,9 @@ def test_units_healpix_to_sky():
     # beam_area = hp.pixelfunc.nside2pixarea(Nside) * units.sr
 
     hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-        os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+        os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
     )
     freqs = freqs * units.Hz
-
     brightness_temperature_conv = units.brightness_temperature(
         freqs, beam_area=beam_area
     )
@@ -705,7 +727,7 @@ def test_param_flux_cuts():
 
 
 def test_point_catalog_reader():
-    catfile = os.path.join(SKY_DATA_PATH, 'pointsource_catalog.txt')
+    catfile = os.path.join(SKY_DATA_PATH, "pointsource_catalog.txt")
     srcs = skymodel.read_text_catalog(catfile)
 
     with open(catfile, "r") as fhandle:
@@ -727,7 +749,7 @@ def test_point_catalog_reader():
     assert srcs.stokes[0] in catalog_table["flux_density_I"]
 
     # Check cuts
-    source_select_kwds = {'min_flux': 1.0}
+    source_select_kwds = {"min_flux": 1.0}
     catalog = skymodel.read_text_catalog(
         catfile, source_select_kwds=source_select_kwds, return_table=True
     )
@@ -777,7 +799,7 @@ def test_flux_cuts():
     maxI_cut = 2.3
 
     cut_sourcelist = skymodel.source_cuts(
-        catalog_table, latitude_deg=30., min_flux=minI_cut, max_flux=maxI_cut
+        catalog_table, latitude_deg=30.0, min_flux=minI_cut, max_flux=maxI_cut
     )
     assert np.all(cut_sourcelist["flux_density_I"] > minI_cut)
     assert np.all(cut_sourcelist["flux_density_I"] < maxI_cut)
@@ -832,12 +854,10 @@ def test_read_gleam():
     assert sourcelist.Ncomponents == 50
 
     # Check cuts
-    source_select_kwds = {'min_flux': 1.0}
+    source_select_kwds = {"min_flux": 1.0}
 
     catalog = skymodel.read_votable_catalog(
-        GLEAM_vot,
-        source_select_kwds=source_select_kwds,
-        return_table=True
+        GLEAM_vot, source_select_kwds=source_select_kwds, return_table=True
     )
 
     assert len(catalog) < sourcelist.Ncomponents
@@ -862,7 +882,7 @@ def test_catalog_file_writer():
     names = "zen_source"
     stokes = [1, 0, 0, 0]
     freqs = [1e8]
-    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, 'flat')
+    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, "flat")
 
     fname = os.path.join(SKY_DATA_PATH, "temp_cat.txt")
 
@@ -874,8 +894,8 @@ def test_catalog_file_writer():
 
 def test_array_to_skymodel_loop():
     sky = skymodel.read_votable_catalog(GLEAM_vot)
-    sky.ra = Angle(sky.ra.rad, 'rad')
-    sky.dec = Angle(sky.dec.rad, 'rad')
+    sky.ra = Angle(sky.ra.rad, "rad")
+    sky.dec = Angle(sky.dec.rad, "rad")
     arr = skymodel.skymodel_to_array(sky)
     sky2 = skymodel.array_to_skymodel(arr)
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -265,12 +265,11 @@ def test_polarized_source_visibilities():
 
 def test_coherency_calc_errors():
     """Test that correct errors are raised when providing invalid location object."""
-    coord = SkyCoord(ra=30.0 * units.deg, dec=40 * units.deg, frame='icrs')
+    coord = SkyCoord(ra=30.0 * units.deg, dec=40 * units.deg, frame="icrs")
 
     stokes_radec = [1, -0.2, 0.3, 0.1]
 
-    source = skymodel.SkyModel('test', coord.ra,
-                               coord.dec, stokes_radec, 1e8, 'flat')
+    source = skymodel.SkyModel("test", coord.ra, coord.dec, stokes_radec, 1e8, "flat")
     time = Time.now()
     array_location = None
     with pytest.raises(ValueError) as err:
@@ -905,32 +904,36 @@ def test_array_to_skymodel_loop():
     assert np.allclose((sky.dec - sky2.dec).rad, 0.0)
 
 
-class TestMoon():
+class TestMoon:
     """
     Series of tests for Moon-based observers
     """
 
     def setup(self):
-        pytest.importorskip('lunarsky')
+        pytest.importorskip("lunarsky")
 
-        from lunarsky import MoonLocation, SkyCoord as SC
+        from lunarsky import MoonLocation, SkyCoord as SkyC
 
         # Tranquility base
-        self.array_location = MoonLocation(lat='00d41m15s', lon='23d26m00s',
-                                           height=0.0)
+        self.array_location = MoonLocation(lat="00d41m15s", lon="23d26m00s", height=0.0)
 
         self.time = Time.now()
-        self.zen_coord = SC(alt=Angle(90, unit=units.deg), az=Angle(0, unit=units.deg),
-                            obstime=self.time, frame='lunartopo', location=self.array_location)
+        self.zen_coord = SkyC(
+            alt=Angle(90, unit=units.deg),
+            az=Angle(0, unit=units.deg),
+            obstime=self.time,
+            frame="lunartopo",
+            location=self.array_location,
+        )
 
-        icrs_coord = self.zen_coord.transform_to('icrs')
+        icrs_coord = self.zen_coord.transform_to("icrs")
 
         ra = icrs_coord.ra
         dec = icrs_coord.dec
-        names = 'zen_source'
+        names = "zen_source"
         stokes = [1, 0, 0, 0]
         freqs = [1e8]
-        self.zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, 'flat')
+        self.zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, "flat")
 
         self.zenith_source.update_positions(self.time, self.array_location)
 
@@ -945,7 +948,7 @@ class TestMoon():
 
         Ntimes = 500
         ets = np.linspace(0, 4 * 28 * 24 * 3600, Ntimes)
-        times = self.time + TimeDelta(ets, format='sec')
+        times = self.time + TimeDelta(ets, format="sec")
 
         lmns = np.zeros((Ntimes, 3))
         for ti in range(Ntimes):
@@ -955,7 +958,7 @@ class TestMoon():
         dt = np.diff(ets)[0]
         _freqs = np.fft.fftfreq(Ntimes, d=dt)
 
-        f_28d = 1 / (28 * 24 * 3600.)
+        f_28d = 1 / (28 * 24 * 3600.0)
 
-        maxf = _freqs[np.argmax(np.abs(_els[_freqs > 0])**2)]
+        maxf = _freqs[np.argmax(np.abs(_els[_freqs > 0]) ** 2)]
         assert np.isclose(maxf, f_28d, atol=2 / ets[-1])

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -17,6 +17,7 @@ from pyradiosky.data import DATA_PATH as SKY_DATA_PATH
 from pyradiosky import utils as skyutils
 from pyradiosky import skymodel
 
+
 GLEAM_vot = os.path.join(SKY_DATA_PATH, "gleam_50srcs.vot")
 
 
@@ -100,6 +101,7 @@ def test_calc_basis_rotation_matrix():
 
     source = skymodel.SkyModel('Test', Angle(12. * units.hr),
                                Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+
     source.update_positions(time, telescope_location)
 
     basis_rot_matrix = source._calc_average_rotation_matrix(telescope_location)
@@ -120,6 +122,7 @@ def test_calc_vector_rotation():
 
     source = skymodel.SkyModel('Test', Angle(12. * units.hr),
                                Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+
     source.update_positions(time, telescope_location)
 
     coherency_rotation = np.squeeze(source._calc_coherency_rotation(telescope_location))
@@ -579,6 +582,7 @@ def test_units_healpix_to_sky():
     Nside = 32
     beam_area = astropy_healpix.nside_to_pixel_area(Nside)  # * units.sr
     # beam_area = hp.pixelfunc.nside2pixarea(Nside) * units.sr
+
     hpmap, inds, freqs = skymodel.read_healpix_hdf5(
         os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
     )
@@ -641,12 +645,15 @@ def test_healpix_positions():
                 d += history_string
             if k in dsets:
                 if np.isscalar(d):
-                    fileobj.create_dataset(
-                        k, data=d, dtype=dsets[k])
+                    fileobj.create_dataset(k, data=d, dtype=dsets[k])
                 else:
                     fileobj.create_dataset(
-                        k, data=d, dtype=dsets[k], compression='gzip',
-                        compression_opts=9)
+                        k,
+                        data=d,
+                        dtype=dsets[k],
+                        compression="gzip",
+                        compression_opts=9,
+                    )
             else:
                 fileobj.attrs[k] = d
 
@@ -654,9 +661,10 @@ def test_healpix_positions():
     array_location = EarthLocation(lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0)
 
     ra, dec = astropy_healpix.healpix_to_lonlat(ipix, Nside)
-    skycoord_use = SkyCoord(ra, dec, frame='icrs')
+    skycoord_use = SkyCoord(ra, dec, frame="icrs")
     source_altaz = skycoord_use.transform_to(
-        AltAz(obstime=time, location=array_location))
+        AltAz(obstime=time, location=array_location)
+    )
     alt_az = np.array([source_altaz.alt.value, source_altaz.az.value])
 
     src_az = Angle(alt_az[1], unit="deg")
@@ -689,7 +697,6 @@ def test_param_flux_cuts():
     # Check that min/max flux limits in test params work.
 
     catalog_table = skymodel.read_votable_catalog(GLEAM_vot, return_table=True)
-
     catalog_table = skymodel.source_cuts(catalog_table, min_flux=0.2, max_flux=1.5)
 
     catalog = skymodel.array_to_skymodel(catalog_table)
@@ -788,8 +795,9 @@ def test_circumpolar_nonrising():
     Nsrcs = 50
 
     j2000 = 2451545.0
-    times = Time(np.linspace(j2000 - 0.5, j2000 + 0.5, Ntimes),
-                 format='jd', scale='utc')
+    times = Time(
+        np.linspace(j2000 - 0.5, j2000 + 0.5, Ntimes), format="jd", scale="utc"
+    )
 
     ra = np.zeros(Nsrcs)
     dec = np.linspace(-90, 90, Nsrcs)

--- a/pyradiosky/tests/test_spherical_coords_transforms.py
+++ b/pyradiosky/tests/test_spherical_coords_transforms.py
@@ -22,8 +22,8 @@ def test_hat_errors(func_name):
 
 @pytest.mark.skip()
 def test_rotate_points_3d():
-    array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
-    time0 = Time('2018-03-01 18:00:00', scale='utc', location=array_location)
+    array_location = EarthLocation(lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0)
+    time0 = Time("2018-03-01 18:00:00", scale="utc", location=array_location)
 
     ha_off = 0.5
     ha_delta = 0.01
@@ -104,16 +104,22 @@ def test_rotate_points_3d():
         R_perturb = sct.vecs2rot(r1=intermediate_vec, r2=altaz_vec)
 
         intermediate_theta, intermediate_phi = sct.rotate_points_3d(
-            R_avg, theta_radec, phi_radec)
-        R_perturb_pts = sct.vecs2rot(theta1=intermediate_theta, phi1=intermediate_phi,
-                                     theta2=theta_altaz, phi2=phi_altaz)
+            R_avg, theta_radec, phi_radec
+        )
+        R_perturb_pts = sct.vecs2rot(
+            theta1=intermediate_theta,
+            phi1=intermediate_phi,
+            theta2=theta_altaz,
+            phi2=phi_altaz,
+        )
 
         assert np.allclose(R_perturb, R_perturb_pts)
 
         R_exact = np.matmul(R_perturb, R_avg)
 
         calc_theta_altaz, calc_phi_altaz = sct.rotate_points_3d(
-            R_exact, theta_radec, phi_radec)
+            R_exact, theta_radec, phi_radec
+        )
 
         if ti == zero_indx:
             assert np.isclose(calc_theta_altaz, theta_altaz, atol=1e-7)
@@ -150,7 +156,7 @@ def test_rotate_points_3d():
     # check errors are raised appropriately
     with pytest.raises(ValueError) as cm:
         sct.rotate_points_3d(R_exact[0:1, :], theta_radec, phi_radec)
-    assert str(cm.value).startswith('rot_matrix must be a 3x3 array')
+    assert str(cm.value).startswith("rot_matrix must be a 3x3 array")
 
     with pytest.raises(ValueError) as cm:
         sct.vecs2rot(r1=intermediate_vec, theta2=theta_altaz, phi2=phi_altaz)

--- a/pyradiosky/tests/test_utils.py
+++ b/pyradiosky/tests/test_utils.py
@@ -11,8 +11,8 @@ import pyradiosky.utils as skyutils
 
 
 def test_tee_ra_loop():
-    time = Time(2457458.1739, scale='utc', format='jd')
-    tee_ra = Angle(np.pi / 4., unit='rad')  # rad
+    time = Time(2457458.1739, scale="utc", format="jd")
+    tee_ra = Angle(np.pi / 4.0, unit="rad")  # rad
     cirs_ra = skyutils._tee_to_cirs_ra(tee_ra, time)
     new_tee_ra = skyutils._cirs_to_tee_ra(cirs_ra, time)
     assert new_tee_ra == tee_ra

--- a/pyradiosky/utils.py
+++ b/pyradiosky/utils.py
@@ -3,7 +3,6 @@
 # Licensed under the 3-clause BSD License
 """Utility methods."""
 
-
 import numpy as np
 from astropy.constants import c
 from astropy import _erfa as erfa
@@ -29,11 +28,10 @@ def _tee_to_cirs_ra(tee_ra, time):
 
     Parameters
     ----------
-    tee_ra : astropy Angle object
+    tee_ra : :class:`astropy.Angle`
         Current epoch RA (RA in the true equator and equinox frame).
-    time : astropy Time object
+    time : :class:`astropy.Time`
         Time object for the epoch of the `tee_ra`.
-
     """
     era = erfa.era00(*get_jd12(time, 'ut1'))
     theta_earth = Angle(era, unit='rad')
@@ -57,11 +55,10 @@ def _cirs_to_tee_ra(cirs_ra, time):
 
     Parameters
     ----------
-    cirs_ra : astropy Angle object
+    cirs_ra : :class:`astropy.Angle`
         CIRS RA.
-    time : astropy Time object
+    time : :class:`astropy.Time`
         Time object for time to convert to the "true equator & equinox" frame.
-
     """
     era = erfa.era00(*get_jd12(time, 'ut1'))
     theta_earth = Angle(era, unit='rad')
@@ -157,7 +154,6 @@ def jy_to_ksr(freqs):
     ----------
     freqs : array_like of float
         Frequencies in Hz.
-
     """
     c_cmps = c.to("cm/s").value  # cm/s
     k_boltz = 1.380658e-16  # erg/K

--- a/pyradiosky/utils.py
+++ b/pyradiosky/utils.py
@@ -33,8 +33,8 @@ def _tee_to_cirs_ra(tee_ra, time):
     time : :class:`astropy.Time`
         Time object for the epoch of the `tee_ra`.
     """
-    era = erfa.era00(*get_jd12(time, 'ut1'))
-    theta_earth = Angle(era, unit='rad')
+    era = erfa.era00(*get_jd12(time, "ut1"))
+    theta_earth = Angle(era, unit="rad")
 
     assert isinstance(time, Time)
     assert isinstance(tee_ra, Angle)
@@ -60,8 +60,8 @@ def _cirs_to_tee_ra(cirs_ra, time):
     time : :class:`astropy.Time`
         Time object for time to convert to the "true equator & equinox" frame.
     """
-    era = erfa.era00(*get_jd12(time, 'ut1'))
-    theta_earth = Angle(era, unit='rad')
+    era = erfa.era00(*get_jd12(time, "ut1"))
+    theta_earth = Angle(era, unit="rad")
 
     assert isinstance(time, Time)
     assert isinstance(cirs_ra, Angle)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ test=pytest
 addopts = --ignore=scripts
 
 [flake8]
-ignore = E501, W503, E203
+ignore = E501, W503, E203, N806
 select = B,C,E,W,T4,B9,F,D,A,RST,N
 max-line-length = 88
 docstring-convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ addopts = --ignore=scripts
 
 [flake8]
 ignore = E501, W503, E203
-select = B,C,E,W,T4,B9,F,D,A,RST
+select = B,C,E,W,T4,B9,F,D,A,RST,N
 max-line-length = 88
 docstring-convention = numpy
 per-file-ignores =

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,12 +9,29 @@ addopts = --ignore=scripts
 
 [flake8]
 ignore = E501, W503, E203
-select = B,C,E,W,T4,B9,F,D
+select = B,C,E,W,T4,B9,F,D,A,RST
 max-line-length = 88
 docstring-convention = numpy
 per-file-ignores =
-    pyradiosky/tests/*.py: D
-    setup.py: D
     __init__.py: F401
+    pyradiosky/tests/*:D
+    setup.py:D
+rst-roles =
+    class
+    func
+    mod
+    data
+    const
+    meth
+    attr
+    exc
+    obj
+rst-directives =
+    note
+    warning
+    versionadded
+    versionchanged
+    deprecated
+    seealso
 # it's recommended to have max-complexity ~ 18
 # max-complexity = 18

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ sys.path.append("pyradiosky")
 # data = [version.git_origin, version.git_hash, version.git_description, version.git_branch]
 # with open(os.path.join('pyradiosky', 'GIT_INFO'), 'w') as outfile:
 #     json.dump(data, outfile)
-class mock_version(object):
+class MockVersion:
     version = 0.0
 
 
-version = mock_version()
+version = MockVersion()
 
 with io.open("README.md", "r", encoding="utf-8") as readme_file:
     readme = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -24,31 +24,30 @@ with io.open("README.md", "r", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 setup_args = {
-    'name': 'pyradiosky',
-    'author': 'Radio Astronomy Software Group',
-    'url': 'https://github.com/RadioAstronomySoftwareGroup/pyradiosky',
-    'license': 'BSD',
-    'description': 'Python objects and interfaces for representing diffuse, extended and compact astrophysical radio sources',
-    'long_description': readme,
-    'long_description_content_type': 'text/markdown',
-    'package_dir': {'pyradiosky': 'pyradiosky'},
-    'packages': ['pyradiosky', 'pyradiosky.tests'],
-    'scripts': glob.glob('scripts/*'),
-    'version': version.version,
-    'include_package_data': True,
-    'install_requires': ['numpy>=1.15', 'scipy', 'astropy>=3.0'],
-    'tests_require': ['pytest'],
-    'extras_require': {
-        'healpix': ['astropy-healpix'],
-        'dev': ['pytest', 'pre-commit']
-    },
-    'classifiers': ['Development Status :: 1 - Planning',
-                    'Intended Audience :: Science/Research',
-                    'License :: OSI Approved :: BSD License',
-                    'Programming Language :: Python :: 3.6',
-                    'Programming Language :: Python :: 3.7',
-                    'Topic :: Scientific/Engineering :: Astronomy'],
-    'keywords': 'radio astronomy'
+    "name": "pyradiosky",
+    "author": "Radio Astronomy Software Group",
+    "url": "https://github.com/RadioAstronomySoftwareGroup/pyradiosky",
+    "license": "BSD",
+    "description": "Python objects and interfaces for representing diffuse, extended and compact astrophysical radio sources",
+    "long_description": readme,
+    "long_description_content_type": "text/markdown",
+    "package_dir": {"pyradiosky": "pyradiosky"},
+    "packages": ["pyradiosky", "pyradiosky.tests"],
+    "scripts": glob.glob("scripts/*"),
+    "version": version.version,
+    "include_package_data": True,
+    "install_requires": ["numpy>=1.15", "scipy", "astropy>=3.0"],
+    "tests_require": ["pytest"],
+    "extras_require": {"healpix": ["astropy-healpix"], "dev": ["pytest", "pre-commit"]},
+    "classifiers": [
+        "Development Status :: 1 - Planning",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering :: Astronomy",
+    ],
+    "keywords": "radio astronomy",
 }
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import glob
 import io
 import sys
+
 from setuptools import setup
 
 sys.path.append("pyradiosky")
@@ -23,30 +24,31 @@ with io.open("README.md", "r", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 setup_args = {
-    "name": "pyradiosky",
-    "author": "Radio Astronomy Software Group",
-    "url": "https://github.com/RadioAstronomySoftwareGroup/pyradiosky",
-    "license": "BSD",
-    "description": "Python objects and interfaces for representing diffuse, extended and compact astrophysical radio sources",
-    "long_description": readme,
-    "long_description_content_type": "text/markdown",
-    "package_dir": {"pyradiosky": "pyradiosky"},
-    "packages": ["pyradiosky", "pyradiosky.tests"],
-    "scripts": glob.glob("scripts/*"),
-    "version": version.version,
-    "include_package_data": True,
-    "install_requires": ["numpy>=1.15", "scipy", "astropy>=4.0", "h5py"],
-    "tests_require": ["pytest"],
-    "extras_require": {"healpix": ["astropy-healpix"]},
-    "classifiers": [
-        "Development Status :: 1 - Planning",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Topic :: Scientific/Engineering :: Astronomy",
-    ],
-    "keywords": "radio astronomy",
+    'name': 'pyradiosky',
+    'author': 'Radio Astronomy Software Group',
+    'url': 'https://github.com/RadioAstronomySoftwareGroup/pyradiosky',
+    'license': 'BSD',
+    'description': 'Python objects and interfaces for representing diffuse, extended and compact astrophysical radio sources',
+    'long_description': readme,
+    'long_description_content_type': 'text/markdown',
+    'package_dir': {'pyradiosky': 'pyradiosky'},
+    'packages': ['pyradiosky', 'pyradiosky.tests'],
+    'scripts': glob.glob('scripts/*'),
+    'version': version.version,
+    'include_package_data': True,
+    'install_requires': ['numpy>=1.15', 'scipy', 'astropy>=3.0'],
+    'tests_require': ['pytest'],
+    'extras_require': {
+        'healpix': ['astropy-healpix'],
+        'dev': ['pytest', 'pre-commit']
+    },
+    'classifiers': ['Development Status :: 1 - Planning',
+                    'Intended Audience :: Science/Research',
+                    'License :: OSI Approved :: BSD License',
+                    'Programming Language :: Python :: 3.6',
+                    'Programming Language :: Python :: 3.7',
+                    'Topic :: Scientific/Engineering :: Astronomy'],
+    'keywords': 'radio astronomy'
 }
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,10 @@ setup_args = {
     "include_package_data": True,
     "install_requires": ["numpy>=1.15", "scipy", "astropy>=4.0", "h5py"],
     "tests_require": ["pytest"],
-    "extras_require": {"healpix": ["astropy-healpix"], "dev": ["pytest", "pre-commit"]},
+    "extras_require": {
+        "healpix": ["astropy-healpix"],
+        "dev": ["pytest", "pre-commit", "astropy-healpix"],
+    },
     "classifiers": [
         "Development Status :: 1 - Planning",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup_args = {
     "scripts": glob.glob("scripts/*"),
     "version": version.version,
     "include_package_data": True,
-    "install_requires": ["numpy>=1.15", "scipy", "astropy>=3.0"],
+    "install_requires": ["numpy>=1.15", "scipy", "astropy>=4.0", "h5py"],
     "tests_require": ["pytest"],
     "extras_require": {"healpix": ["astropy-healpix"], "dev": ["pytest", "pre-commit"]},
     "classifiers": [


### PR DESCRIPTION
Adds pre-commit, and also a whole lot of automatic flake8 goodness.

Fixes #40 
Fixes #29 

Since this changes a lot of files, it might be a bit tricky to merge with other PRs on the loose. 

So far, I've added 

```
- flake8-docstrings
- flake8-rst-docstrings
- flake8-comprehensions
- flake8-black
- flake8-builtins
- flake8-copyright
```

and made changes in the code to make these pass.

I think we should also enable `pep8-naming` and `flake8-eradicate`, but I want to hear others' opinions first. Adding pep8-naming gives the following errors:

```
pyradiosky/skymodel.py:200:10: N806 variable 'R_screwy' in function should be lowercase
pyradiosky/skymodel.py:201:10: N806 variable 'R_really_orthogonal' in function should be lowercase
pyradiosky/skymodel.py:204:10: N806 variable 'R_really_orthogonal' in function should be lowercase
pyradiosky/skymodel.py:235:10: N806 variable 'R_avg' in function should be lowercase
pyradiosky/skymodel.py:237:10: N806 variable 'R_exact' in function should be lowercase
pyradiosky/skymodel.py:242:14: N806 variable 'R_perturb' in function should be lowercase
pyradiosky/skymodel.py:311:10: N806 variable 'Ionly_mask' in function should be lowercase
pyradiosky/skymodel.py:312:10: N806 variable 'NstokesI' in function should be lowercase
pyradiosky/skymodel.py:326:14: N806 variable 'rotation_matrix_T' in function should be lowercase
pyradiosky/skymodel.py:456:6: N806 variable 'Nside' in function should be lowercase
pyradiosky/skymodel.py:492:6: N806 variable 'flux_I' in function should be lowercase
pyradiosky/skymodel.py:494:10: N806 variable 'flux_I' in function should be lowercase
pyradiosky/skymodel.py:646:6: N806 variable 'Nsrcs' in function should be lowercase
pyradiosky/tests/test_utils.py:23:6: N806 variable 'stokesI' in function should be lowercase
pyradiosky/tests/test_utils.py:24:6: N806 variable 'stokesQ' in function should be lowercase
pyradiosky/tests/test_utils.py:25:6: N806 variable 'stokesU' in function should be lowercase
pyradiosky/tests/test_utils.py:26:6: N806 variable 'stokesV' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:176:6: N806 variable 'cosX' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:177:6: N806 variable 'sinX' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:203:6: N806 variable 'K_matrix' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:207:6: N806 variable 'I_matrix' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:290:6: N806 variable 'sinPsi' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:292:6: N806 variable 'cosPsi' in function should be lowercase
pyradiosky/spherical_coords_transforms.py:293:6: N806 variable 'Psi' in function should be lowercase
pyradiosky/tests/test_skymodel.py:167:6: N806 variable 'B' in function should be lowercase
pyradiosky/tests/test_skymodel.py:168:6: N806 variable 'J' in function should be lowercase
pyradiosky/tests/test_skymodel.py:232:6: N806 variable 'Jbeam' in function should be lowercase
pyradiosky/tests/test_skymodel.py:327:6: N806 variable 'Jbeam' in function should be lowercase
pyradiosky/tests/test_skymodel.py:357:6: N806 variable 'Nside' in function should be lowercase
pyradiosky/tests/test_skymodel.py:359:6: N806 variable 'Npix' in function should be lowercase
pyradiosky/tests/test_skymodel.py:473:6: N806 variable 'Nside' in function should be lowercase
pyradiosky/tests/test_skymodel.py:474:6: N806 variable 'Npix' in function should be lowercase
pyradiosky/tests/test_skymodel.py:582:6: N806 variable 'Nside' in function should be lowercase
pyradiosky/tests/test_skymodel.py:601:6: N806 variable 'Nside' in function should be lowercase
pyradiosky/tests/test_skymodel.py:602:6: N806 variable 'Npix' in function should be lowercase
pyradiosky/tests/test_skymodel.py:604:6: N806 variable 'Nfreqs' in function should be lowercase
pyradiosky/tests/test_skymodel.py:610:6: N806 variable 'Nskies' in function should be lowercase
pyradiosky/tests/test_skymodel.py:710:10: N806 variable 'sI' in function should be lowercase
pyradiosky/tests/test_skymodel.py:745:6: N806 variable 'Nsrcs' in function should be lowercase
pyradiosky/tests/test_skymodel.py:763:6: N806 variable 'minI_cut' in function should be lowercase
pyradiosky/tests/test_skymodel.py:764:6: N806 variable 'maxI_cut' in function should be lowercase
pyradiosky/tests/test_skymodel.py:781:6: N806 variable 'Ntimes' in function should be lowercase
pyradiosky/tests/test_skymodel.py:782:6: N806 variable 'Nsrcs' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:84:10: N806 variable 'R_screwy' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:85:10: N806 variable 'R_avg' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:88:10: N806 variable 'R_avg' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:104:10: N806 variable 'R_perturb' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:109:10: N806 variable 'R_perturb_pts' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:118:10: N806 variable 'R_exact' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:136:10: N806 variable 'Rv1' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:174:6: N806 variable 'sinPsi' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:176:6: N806 variable 'cosPsi' in function should be lowercase
pyradiosky/tests/test_spherical_coords_transforms.py:177:6: N806 variable 'Psi' in function should be lowercase
setup.py:19:8: N801 class name 'mock_version' should use CapWords convention
```

I don't know how rigorous we want to be with our pep8 naming or how akward it will be to change these names. I'm up for doing it, but will wait for other's opinions.