### PR TITLE
Write healpix

### DIFF
--- a/pyradiosky/__init__.py
+++ b/pyradiosky/__init__.py
@@ -11,5 +11,5 @@ from .skymodel import (
     read_text_catalog,
     read_idl_catalog,
     write_catalog_to_file,
-    write_healpix_hdf5
+    write_healpix_hdf5,
 )

--- a/pyradiosky/__init__.py
+++ b/pyradiosky/__init__.py
@@ -11,4 +11,5 @@ from .skymodel import (
     read_text_catalog,
     read_idl_catalog,
     write_catalog_to_file,
+    write_healpix_hdf5
 )

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -497,6 +497,27 @@ def read_healpix_hdf5(hdf5_filename):
 
 
 def write_healpix_hdf5(filename, hpmap, indices, freqs, Nside=None, history=None):
+    """
+    Write a set of HEALPix maps to an HDF5 file.
+
+    Parameters
+    ----------
+    filename: str
+        Name of file to write to.
+    hpmap: array_like of float
+        Pixel values in Kelvin. Shape (Nfreqs, Npix)
+    indices: array_like of int
+        HEALPix pixel indices corresponding with axis 1 of hpmap.
+    freqs: array_like of floats
+        Frequencies in Hz corresponding with axis 0 of hpmap.
+    Nside: int
+        Nside parameter of the map. Optional if the hpmap covers
+        the full sphere (i.e., has no missing pixels), since the Nside
+        can be inferred from the map size.
+    history: str
+        Optional history string to include in the file.
+
+    """
     try:
         import astropy_healpix
     except ImportError as e:
@@ -528,7 +549,7 @@ def write_healpix_hdf5(filename, hpmap, indices, freqs, Nside=None, history=None
         "Nfreqs": Nfreqs,
         "data": hpmap[None, ...],
         "indices": indices,
-        "freqs": freqs.to('Hz').value,
+        "freqs": freqs,
         "history": history,
     }
     dsets = {

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -31,6 +31,7 @@ __all__ = [
     "read_text_catalog",
     "read_idl_catalog",
     "write_catalog_to_file",
+    "write_healpix_hdf5",
 ]
 
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -389,14 +389,14 @@ class TestHealpixHdf5():
         freqs = freqs * units.Hz
         filename = 'tempfile.hdf5'
         with pytest.raises(ValueError) as verr:
-            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs)
+            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs.to("Hz").value)
         assert str(verr.value).startswith("Need to provide Nside if giving a subset of the map.")
 
         with pytest.raises(ValueError) as verr:
-            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs.value, Nside=self.Nside)
+            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs.to("Hz").value, Nside=self.Nside)
         assert str(verr.value).startswith("Invalid map shape")
 
-        skymodel.write_healpix_hdf5(filename, hpmap, inds, freqs)
+        skymodel.write_healpix_hdf5(filename, hpmap, inds, freqs.to("Hz").value)
 
         hpmap_new, inds_new, freqs_new = skymodel.read_healpix_hdf5(filename)
 
@@ -437,7 +437,7 @@ def test_healpix_positions():
 
     filename = os.path.join(SKY_DATA_PATH, "healpix_single.hdf5")
 
-    skymodel.write_healpix_hdf5(filename, hpx_map, range(Npix), freqs * units.Hz)
+    skymodel.write_healpix_hdf5(filename, hpx_map, range(Npix), freqs)
 
     time = Time("2018-03-01 00:00:00", scale="utc")
     array_location = EarthLocation(lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0)

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -315,7 +315,26 @@ def test_polarized_source_smooth_visibilities():
         assert np.all(imag_stokes == 0)
 
 
+def test_coherency_calc_errors():
+    """Test that correct errors are raised when providing invalid location object."""
+    coord = SkyCoord(ra=30.0 * units.deg, dec=40 * units.deg, frame="icrs")
+
+    stokes_radec = [1, -0.2, 0.3, 0.1]
+
+    source = skymodel.SkyModel("test", coord.ra, coord.dec, stokes_radec, 1e8, "flat")
+    time = Time.now()
+    array_location = None
+    with pytest.raises(ValueError) as err:
+        source.update_positions(time, telescope_location=array_location)
+    assert str(err.value).startswith("telescope_location must be an")
+
+    with pytest.raises(ValueError) as err:
+        source.coherency_calc(array_location).squeeze()
+    assert str(err.value).startswith("telescope_location must be an")
+
+
 class TestHealpixHdf5():
+
     pytest.importorskip('astropy_healpix')
 
     def setup(self):
@@ -337,7 +356,6 @@ class TestHealpixHdf5():
         )
 
     def test_read_healpix_hdf5(self):
-
         m = np.arange(self.Npix)
         m[self.ipix_disc] = self.Npix - 1
 
@@ -367,7 +385,6 @@ class TestHealpixHdf5():
         assert np.allclose(sky.stokes[0], hmap_orig.value)
 
     def test_units_healpix_to_sky(self):
-
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
             os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
         )
@@ -382,7 +399,6 @@ class TestHealpixHdf5():
         assert np.allclose(sky.stokes[0, 0], stokes.value[0])
 
     def test_read_write_healpix(self):
-
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
             os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
         )

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -459,15 +459,18 @@ def test_healpix_import_err():
 
         astropy_healpix.nside_to_npix(2 ** 3)
     except ImportError:
+        errstr = "The astropy-healpix module must be installed to use HEALPix methods"
+        Npix = 12
+        hpmap = np.arange(Npix)
+        inds = hpmap
+        freqs = np.zeros(1)
         with pytest.raises(ImportError) as cm:
-            Npix = 12
-            hpmap = np.arange(Npix)
-            inds = hpmap
-            freqs = np.zeros(1)
             skymodel.healpix_to_sky(hpmap, inds, freqs)
-        assert str(cm.value).startswith(
-            "The astropy-healpix module must be installed to use HEALPix methods"
-        )
+        assert str(cm.value).startswith(errstr)
+
+        with pytest.raises(ImportError) as cm:
+            skymodel.write_healpix_hdf5("filename.hdf5", hpmap, inds, freqs)
+        assert str(cm.value).startswith(errstr)
 
 
 def test_healpix_positions():

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -43,16 +43,18 @@ def test_source_zenith_from_icrs():
     dec = icrs_coord.dec
     # Check error cases
     with pytest.raises(ValueError) as cm:
-        skymodel.SkyModel('icrs_zen', ra.rad, dec.rad, [1, 0, 0, 0], 1e8, 'flat')
-    assert str(cm.value).startswith('ra must be an astropy Angle object. '
-                                    'value was: 3.14')
+        skymodel.SkyModel("icrs_zen", ra.rad, dec.rad, [1, 0, 0, 0], 1e8, "flat")
+    assert str(cm.value).startswith(
+        "ra must be an astropy Angle object. " "value was: 3.14"
+    )
 
     with pytest.raises(ValueError) as cm:
-        skymodel.SkyModel('icrs_zen', ra, dec.rad, [1, 0, 0, 0], 1e8, 'flat')
-    assert str(cm.value).startswith('dec must be an astropy Angle object. '
-                                    'value was: -0.53')
+        skymodel.SkyModel("icrs_zen", ra, dec.rad, [1, 0, 0, 0], 1e8, "flat")
+    assert str(cm.value).startswith(
+        "dec must be an astropy Angle object. " "value was: -0.53"
+    )
 
-    zenith_source = skymodel.SkyModel('icrs_zen', ra, dec, [1, 0, 0, 0], 1e8, 'flat')
+    zenith_source = skymodel.SkyModel("icrs_zen", ra, dec, [1, 0, 0, 0], 1e8, "flat")
 
     zenith_source.update_positions(time, array_location)
     zenith_source_lmn = zenith_source.pos_lmn.squeeze()
@@ -80,7 +82,7 @@ def test_source_zenith():
     names = "zen_source"
     stokes = [1, 0, 0, 0]
     freqs = [1e8]
-    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, 'flat')
+    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, "flat")
 
     zenith_source.update_positions(time, array_location)
     zenith_source_lmn = zenith_source.pos_lmn.squeeze()
@@ -93,12 +95,19 @@ def test_calc_basis_rotation_matrix():
     actually a rotation matrix (R R^T = R^T R = I)
     """
 
-    time = Time('2018-01-01 00:00')
+    time = Time("2018-01-01 00:00")
     telescope_location = EarthLocation(
-        lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
+        lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0
+    )
 
-    source = skymodel.SkyModel('Test', Angle(12. * units.hr),
-                               Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "Test",
+        Angle(12.0 * units.hr),
+        Angle(-30.0 * units.deg),
+        [1.0, 0.0, 0.0, 0.0],
+        1e8,
+        "flat",
+    )
     source.update_positions(time, telescope_location)
 
     basis_rot_matrix = source._calc_average_rotation_matrix(telescope_location)
@@ -113,12 +122,19 @@ def test_calc_vector_rotation():
     I suppose we could also have checked (R R^T = R^T R = I)
     """
 
-    time = Time('2018-01-01 00:00')
+    time = Time("2018-01-01 00:00")
     telescope_location = EarthLocation(
-        lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
+        lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0
+    )
 
-    source = skymodel.SkyModel('Test', Angle(12. * units.hr),
-                               Angle(-30. * units.deg), [1., 0., 0., 0.], 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "Test",
+        Angle(12.0 * units.hr),
+        Angle(-30.0 * units.deg),
+        [1.0, 0.0, 0.0, 0.0],
+        1e8,
+        "flat",
+    )
     source.update_positions(time, telescope_location)
 
     coherency_rotation = np.squeeze(source._calc_coherency_rotation(telescope_location))
@@ -174,8 +190,14 @@ def test_polarized_source_visibilities():
     decoff = 0.0 * units.arcmin  # -0.17 * units.arcsec
     raoff = 0.0 * units.arcsec
 
-    source = skymodel.SkyModel('icrs_zen', zenith_icrs.ra + raoff,
-                               zenith_icrs.dec + decoff, stokes_radec, 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "icrs_zen",
+        zenith_icrs.ra + raoff,
+        zenith_icrs.dec + decoff,
+        stokes_radec,
+        1e8,
+        "flat",
+    )
 
     coherency_matrix_local = np.zeros([2, 2, ntimes], dtype="complex128")
     alts = np.zeros(ntimes)
@@ -268,8 +290,9 @@ def test_polarized_source_smooth_visibilities():
 
     stokes_radec = [1, -0.2, 0.3, 0.1]
 
-    source = skymodel.SkyModel('icrs_zen', zenith_icrs.ra,
-                               zenith_icrs.dec, stokes_radec, 1e8, 'flat')
+    source = skymodel.SkyModel(
+        "icrs_zen", zenith_icrs.ra, zenith_icrs.dec, stokes_radec, 1e8, "flat"
+    )
 
     coherency_matrix_local = np.zeros([2, 2, ntimes], dtype="complex128")
     alts = np.zeros(ntimes)
@@ -333,24 +356,25 @@ def test_coherency_calc_errors():
     assert str(err.value).startswith("telescope_location must be an")
 
 
-class TestHealpixHdf5():
+class TestHealpixHdf5:
 
-    pytest.importorskip('astropy_healpix')
+    pytest.importorskip("astropy_healpix")
 
     def setup(self):
         # Common features of tests
         import astropy_healpix
-        self.Nside = 32
-        self.Npix = astropy_healpix.nside_to_npix(self.Nside)
-        hp_obj = astropy_healpix.HEALPix(nside=self.Nside)
+
+        self.nside = 32
+        self.Npix = astropy_healpix.nside_to_npix(self.nside)
+        hp_obj = astropy_healpix.HEALPix(nside=self.nside)
         self.frequencies = np.linspace(100, 110, 10)
-        self.pixel_area = astropy_healpix.nside_to_pixel_area(self.Nside)
+        self.pixel_area = astropy_healpix.nside_to_pixel_area(self.nside)
         # Note that the cone search includes any pixels that overlap with the search
         # region. With such a low resolution, this returns some slightly different
         # results from the equivalent healpy search. Subtracting(0.75 * pixres) from
         # the pixel area resolves this discrepancy for the test.
 
-        pixres = hp_obj.pixel_resolution.to('deg').value
+        pixres = hp_obj.pixel_resolution.to("deg").value
         self.ipix_disc = hp_obj.cone_search_lonlat(
             135 * units.deg, 0 * units.deg, radius=(10 - pixres * 0.75) * units.deg
         )
@@ -362,7 +386,7 @@ class TestHealpixHdf5():
         indices = np.arange(self.Npix)
 
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-            os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+            os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
         )
 
         assert np.allclose(hpmap[0, :], m)
@@ -371,7 +395,7 @@ class TestHealpixHdf5():
 
     def test_healpix_to_sky(self):
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-            os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+            os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
         )
 
         hmap_orig = np.arange(self.Npix)
@@ -386,7 +410,7 @@ class TestHealpixHdf5():
 
     def test_units_healpix_to_sky(self):
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-            os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+            os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
         )
         freqs = freqs * units.Hz
 
@@ -400,16 +424,22 @@ class TestHealpixHdf5():
 
     def test_read_write_healpix(self):
         hpmap, inds, freqs = skymodel.read_healpix_hdf5(
-            os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+            os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5")
         )
         freqs = freqs * units.Hz
-        filename = 'tempfile.hdf5'
+        filename = "tempfile.hdf5"
         with pytest.raises(ValueError) as verr:
-            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs.to("Hz").value)
-        assert str(verr.value).startswith("Need to provide Nside if giving a subset of the map.")
+            skymodel.write_healpix_hdf5(
+                filename, hpmap, inds[:10], freqs.to("Hz").value
+            )
+        assert str(verr.value).startswith(
+            "Need to provide nside if giving a subset of the map."
+        )
 
         with pytest.raises(ValueError) as verr:
-            skymodel.write_healpix_hdf5(filename, hpmap, inds[:10], freqs.to("Hz").value, Nside=self.Nside)
+            skymodel.write_healpix_hdf5(
+                filename, hpmap, inds[:10], freqs.to("Hz").value, nside=self.nside
+            )
         assert str(verr.value).startswith("Invalid map shape")
 
         skymodel.write_healpix_hdf5(filename, hpmap, inds, freqs.to("Hz").value)
@@ -426,7 +456,8 @@ class TestHealpixHdf5():
 def test_healpix_import_err():
     try:
         import astropy_healpix
-        astropy_healpix.nside_to_npix(2**3)
+
+        astropy_healpix.nside_to_npix(2 ** 3)
     except ImportError:
         with pytest.raises(ImportError) as cm:
             Npix = 12
@@ -434,16 +465,18 @@ def test_healpix_import_err():
             inds = hpmap
             freqs = np.zeros(1)
             skymodel.healpix_to_sky(hpmap, inds, freqs)
-        assert str(cm.value).startswith("The astropy-healpix module must be installed to use HEALPix methods")
+        assert str(cm.value).startswith(
+            "The astropy-healpix module must be installed to use HEALPix methods"
+        )
 
 
 def test_healpix_positions():
-    pytest.importorskip('astropy_healpix')
+    pytest.importorskip("astropy_healpix")
     import astropy_healpix
 
     # write out a healpix file, read it back in check that it is as expected
-    Nside = 8
-    Npix = astropy_healpix.nside_to_npix(Nside)
+    nside = 8
+    Npix = astropy_healpix.nside_to_npix(nside)
     freqs = np.arange(100, 100.5, 0.1) * 1e6
     Nfreqs = len(freqs)
     hpx_map = np.zeros((Nfreqs, Npix))
@@ -458,10 +491,11 @@ def test_healpix_positions():
     time = Time("2018-03-01 00:00:00", scale="utc")
     array_location = EarthLocation(lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0)
 
-    ra, dec = astropy_healpix.healpix_to_lonlat(ipix, Nside)
-    skycoord_use = SkyCoord(ra, dec, frame='icrs')
+    ra, dec = astropy_healpix.healpix_to_lonlat(ipix, nside)
+    skycoord_use = SkyCoord(ra, dec, frame="icrs")
     source_altaz = skycoord_use.transform_to(
-        AltAz(obstime=time, location=array_location))
+        AltAz(obstime=time, location=array_location)
+    )
     alt_az = np.array([source_altaz.alt.value, source_altaz.az.value])
 
     src_az = Angle(alt_az[1], unit="deg")
@@ -503,7 +537,7 @@ def test_param_flux_cuts():
 
 
 def test_point_catalog_reader():
-    catfile = os.path.join(SKY_DATA_PATH, 'pointsource_catalog.txt')
+    catfile = os.path.join(SKY_DATA_PATH, "pointsource_catalog.txt")
     srcs = skymodel.read_text_catalog(catfile)
 
     with open(catfile, "r") as fhandle:
@@ -525,7 +559,7 @@ def test_point_catalog_reader():
     assert srcs.stokes[0] in catalog_table["flux_density_I"]
 
     # Check cuts
-    source_select_kwds = {'min_flux': 1.0}
+    source_select_kwds = {"min_flux": 1.0}
     catalog = skymodel.read_text_catalog(
         catfile, source_select_kwds=source_select_kwds, return_table=True
     )
@@ -575,7 +609,7 @@ def test_flux_cuts():
     maxI_cut = 2.3
 
     cut_sourcelist = skymodel.source_cuts(
-        catalog_table, latitude_deg=30., min_flux=minI_cut, max_flux=maxI_cut
+        catalog_table, latitude_deg=30.0, min_flux=minI_cut, max_flux=maxI_cut
     )
     assert np.all(cut_sourcelist["flux_density_I"] > minI_cut)
     assert np.all(cut_sourcelist["flux_density_I"] < maxI_cut)
@@ -593,8 +627,9 @@ def test_circumpolar_nonrising():
     Nsrcs = 50
 
     j2000 = 2451545.0
-    times = Time(np.linspace(j2000 - 0.5, j2000 + 0.5, Ntimes),
-                 format='jd', scale='utc')
+    times = Time(
+        np.linspace(j2000 - 0.5, j2000 + 0.5, Ntimes), format="jd", scale="utc"
+    )
 
     ra = np.zeros(Nsrcs)
     dec = np.linspace(-90, 90, Nsrcs)
@@ -629,11 +664,9 @@ def test_read_gleam():
     assert sourcelist.Ncomponents == 50
 
     # Check cuts
-    source_select_kwds = {'min_flux': 1.0}
+    source_select_kwds = {"min_flux": 1.0}
     catalog = skymodel.read_votable_catalog(
-        GLEAM_vot,
-        source_select_kwds=source_select_kwds,
-        return_table=True
+        GLEAM_vot, source_select_kwds=source_select_kwds, return_table=True
     )
 
     assert len(catalog) < sourcelist.Ncomponents
@@ -658,7 +691,7 @@ def test_catalog_file_writer():
     names = "zen_source"
     stokes = [1, 0, 0, 0]
     freqs = [1e8]
-    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, 'flat')
+    zenith_source = skymodel.SkyModel(names, ra, dec, stokes, freqs, "flat")
 
     fname = os.path.join(SKY_DATA_PATH, "temp_cat.txt")
 
@@ -670,8 +703,8 @@ def test_catalog_file_writer():
 
 def test_array_to_skymodel_loop():
     sky = skymodel.read_votable_catalog(GLEAM_vot)
-    sky.ra = Angle(sky.ra.rad, 'rad')
-    sky.dec = Angle(sky.dec.rad, 'rad')
+    sky.ra = Angle(sky.ra.rad, "rad")
+    sky.dec = Angle(sky.dec.rad, "rad")
     arr = skymodel.skymodel_to_array(sky)
     sky2 = skymodel.array_to_skymodel(arr)
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -357,11 +357,9 @@ def test_coherency_calc_errors():
 
 
 class TestHealpixHdf5:
-
-    pytest.importorskip("astropy_healpix")
-
     def setup(self):
         # Common features of tests
+        pytest.importorskip("astropy_healpix")
         import astropy_healpix
 
         self.nside = 32


### PR DESCRIPTION
Adds a method to write a HEALPix + frequency sky model to the HDF5 format. This is necessary for the benchmarking branch on `pyuvsim`.

Also cleans up the HEALPix reader tests a little.