### PR TITLE
Speedup changes

### DIFF
--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -284,12 +284,12 @@ class SkyModel(UVBase):
         )
 
         desc = (
-            "Boolean indicator of whether this source is below the horizon"
+            "Boolean indicator of whether this source is above the horizon"
             "at the current time."
-            "True indicates the source is below the horizon."
+            "True indicates the source is above the horizon."
         )
-        self._below_horizon = UVParameter(
-            "below_horizon",
+        self._above_horizon = UVParameter(
+            "above_horizon",
             description=desc,
             form=("Ncomponents",),
             expected_type=bool,
@@ -613,12 +613,12 @@ class SkyModel(UVBase):
         array of float
             local coherency in alt/az basis, shape (2, 2, Nfreqs, Ncomponents)
         """
-        if self.below_horizon is None:
+        if self.above_horizon is None:
             warnings.warn(
-                "Horizon cutoff undefined. Assuming all source components are"
-                " above the horizon."
+                "Horizon cutoff undefined. Assuming all source components "
+                "are above the horizon."
             )
-            self.below_horizon = np.zeros(self.Ncomponents).astype(bool)
+            self.above_horizon = np.ones(self.Ncomponents).astype(bool)
 
         if deprecated_location is not None:
             warnings.warn(
@@ -639,13 +639,13 @@ class SkyModel(UVBase):
             )
 
         # Select sources within the horizon only.
-        coherency_local = self.coherency_radec[..., ~self.below_horizon]
+        coherency_local = self.coherency_radec[..., self.above_horizon]
 
         # For unpolarized sources, there's no need to rotate the coherency matrix.
         if self._n_polarized > 0:
             # If there are any polarized sources, do rotation.
 
-            pol_over_hor = np.where(~self.below_horizon[self._polarized])[0]
+            pol_over_hor = np.where(self.above_horizon[self._polarized])[0]
 
             if len(pol_over_hor) > 0:
 
@@ -726,7 +726,7 @@ class SkyModel(UVBase):
         self.pos_lmn[2, :] = pos_n
 
         # Horizon mask:
-        self.below_horizon = self.alt_az[0, :] < 0.0
+        self.above_horizon = self.alt_az[0, :] > 0.0
 
 
 def read_healpix_hdf5(hdf5_filename):

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -594,7 +594,9 @@ class SkyModel(UVBase):
 
     def coherency_calc(self, deprecated_location=None):
         """
-        Calculate the local coherency in alt/az basis for this source at a time & location.
+        Calculate the local coherency in alt/az basis.
+
+        SkyModel.update_positions() must be run prior to this method.
 
         The coherency is a 2x2 matrix giving electric field correlation in Jy.
         It's specified on the object as a coherency in the ra/dec basis,
@@ -611,6 +613,13 @@ class SkyModel(UVBase):
         array of float
             local coherency in alt/az basis, shape (2, 2, Nfreqs, Ncomponents)
         """
+        if self.below_horizon is None:
+            warnings.warn(
+                "Horizon cutoff undefined. Assuming all source components are"
+                " above the horizon."
+            )
+            self.below_horizon = np.zeros(self.Ncomponents).astype(bool)
+
         if deprecated_location is not None:
             warnings.warn(
                 "Passing telescope_location to SkyModel.coherency_calc is "
@@ -893,7 +902,6 @@ def skymodel_to_array(sky):
     fieldshapes = [()] * 3
 
     n_stokes = 4
-    # TODO -- Only extend the flux axis with polarization if there are multiple pols.
 
     if sky.freq_array is not None:
         if sky.spectral_type == "subband":

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -898,10 +898,10 @@ def test_flux_cuts(spec_type, init_kwargs, cut_kwargs):
     if "freq_range" in cut_kwargs and np.min(
         cut_kwargs["freq_range"] > np.min(init_kwargs["freq_array"])
     ):
-        assert np.all(cut_sourcelist["flux_density_I"] < maxI_cut)
+        assert np.all(cut_sourcelist["flux_density"][..., 0] < maxI_cut)
     else:
-        assert np.all(cut_sourcelist["flux_density_I"] > minI_cut)
-        assert np.all(cut_sourcelist["flux_density_I"] < maxI_cut)
+        assert np.all(cut_sourcelist["flux_density"][..., 0] > minI_cut)
+        assert np.all(cut_sourcelist["flux_density"][..., 0] < maxI_cut)
 
 
 @pytest.mark.parametrize(
@@ -1224,7 +1224,7 @@ def test_point_catalog_reader():
     header = [h.strip() for h in header.split()]
     dt = np.format_parser(
         ["U10", "f8", "f8", "f8", "f8"],
-        ["source_id", "ra_j2000", "dec_j2000", "flux_density_I", "frequency"],
+        ["source_id", "ra_j2000", "dec_j2000", "flux_density", "frequency"],
         header,
     )
 
@@ -1235,7 +1235,7 @@ def test_point_catalog_reader():
     assert sorted(srcs.name) == sorted(catalog_table["source_id"])
     assert srcs.ra.deg in catalog_table["ra_j2000"]
     assert srcs.dec.deg in catalog_table["dec_j2000"]
-    assert srcs.stokes[0] in catalog_table["flux_density_I"]
+    assert srcs.stokes in catalog_table["flux_density"]
 
     # Check cuts
     source_select_kwds = {"min_flux": 1.0}

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -377,8 +377,9 @@ def test_coherency_calc_errors():
 
     source = skymodel.SkyModel("test", coord.ra, coord.dec, stokes_radec, "flat")
 
-    with pytest.raises(ValueError, match="telescope_location must be an"):
-        source.coherency_calc().squeeze()
+    with pytest.warns(UserWarning, match="Horizon cutoff undefined"):
+        with pytest.raises(ValueError, match="telescope_location must be an"):
+            source.coherency_calc().squeeze()
 
 
 def test_calc_basis_rotation_matrix():


### PR DESCRIPTION
Implements a few changes to speed up calculations. This includes:
- `coherency_calc` will only calculate the coherency matrix for source components that are above the horizon.
- Previously if _any_ sources were polarized, the coherency rotation matrices were calculated for all of sources (including unpolarized). Now they will only be calculated for polarized sources.

This also includes a change to keep all four Stokes parameters when converting to/from recarray.