### PR TITLE
put read_gleam_catalog in namespace

### DIFF
--- a/pyradiosky/__init__.py
+++ b/pyradiosky/__init__.py
@@ -28,6 +28,7 @@ from .skymodel import (
     array_to_skymodel,
     source_cuts,
     read_votable_catalog,
+    read_gleam_catalog,
     read_text_catalog,
     read_idl_catalog,
     write_catalog_to_file,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the `read_gleam_catalog` function to the pyradiosky namespace.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme
