### PR TITLE
Fixed a tolerance issue on arccos of slightly >1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+## Fixed
+- A bug in `spherical_coords_transforms.rotate_points_3d` where an arcos
+calculation failed for a value larger than one by ~1e-12.
 
 ## [0.0.1] - 2020-4-6
 

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -127,7 +127,7 @@ def rotate_points_3d(rot_matrix, theta, phi):
 
     # Should write a function to do this as well, i.e., pull back angles from
     # a vector
-    if np.isclose(p_hat[2], 1.0, rtol=0., atol=1e-12):
+    if np.isclose(p_hat[2], 1.0, rtol=0.0, atol=1e-12):
         p_hat[2] = 1.0
     beta = np.arccos(p_hat[2])
     alpha = np.arctan2(p_hat[1], p_hat[0])

--- a/pyradiosky/spherical_coords_transforms.py
+++ b/pyradiosky/spherical_coords_transforms.py
@@ -122,13 +122,16 @@ def rotate_points_3d(rot_matrix, theta, phi):
     q_hat_3 = np.cos(theta)
     q_hat = np.stack((q_hat_1, q_hat_2, q_hat_3))
 
-    p_hat = np.einsum("ab...,b...->a...", rot_matrix, q_hat)
     # Should test for shape of p_hat
+    p_hat = np.einsum("ab...,b...->a...", rot_matrix, q_hat)
 
     # Should write a function to do this as well, i.e., pull back angles from
     # a vector
+    if np.isclose(p_hat[2], 1.0, rtol=0., atol=1e-12):
+        p_hat[2] = 1.0
     beta = np.arccos(p_hat[2])
     alpha = np.arctan2(p_hat[1], p_hat[0])
+
     if alpha < 0:
         alpha += 2.0 * np.pi
 

--- a/pyradiosky/tests/test_spherical_coords_transforms.py
+++ b/pyradiosky/tests/test_spherical_coords_transforms.py
@@ -20,7 +20,6 @@ def test_hat_errors(func_name):
     assert str(cm.value).startswith("theta and phi must have the same shape")
 
 
-@pytest.mark.skip()
 def test_rotate_points_3d():
     array_location = EarthLocation(lat="-30d43m17.5s", lon="21d25m41.9s", height=1073.0)
     time0 = Time("2018-03-01 18:00:00", scale="utc", location=array_location)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In `rotate_points_3d` in `spherical_coords_transforms`, there's an arccos function, the argument of which can be _slightly_ bigger than 1 in the case that the point is rotated near to the pole of the coordinate system.  Forced it to be exactly 1 if it's close to 1 with an absolute tolerance of 1e-12.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Closes #6 

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/master/CHANGELOG.md).
