### PR TITLE
Evaluate Stokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ## Added
-- An `evaluate_stokes` function that will return a new SkyModel at requested frequencies.
+- An `at_frequencies` function that will return a new SkyModel at requested frequencies.
 - A new `component_type` parameter that can be set to "healpix" or "point".
 - Better support for HEALPix maps, with new `nside` and `hpx_inds` parameters.
 - Added the following methods to the `SkyModel` class: `select`, `source_cuts`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ## Added
+- An `evaluate_stokes` function that will return a new SkyModel at requested frequencies.
 - A new `component_type` parameter that can be set to "healpix" or "point".
 - Better support for HEALPix maps, with new `nside` and `hpx_inds` parameters.
 - Added the following methods to the `SkyModel` class: `select`, `source_cuts`,

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -631,12 +631,7 @@ class SkyModel(UVBase):
         return equal
 
     def evaluate_stokes(
-        self,
-        freqs,
-        inplace=True,
-        squeeze_flat=False,
-        freq_interp_kind="cubic",
-        run_check=True,
+        self, freqs, inplace=True, freq_interp_kind="cubic", run_check=True,
     ):
         """
         Evaluate the stokes array to specified frequencies.
@@ -648,10 +643,6 @@ class SkyModel(UVBase):
         - spectral_index: Evaluate at the new frequencies.
         - flat: Copy to new frequencies.
 
-        Alternatively, if the "squeeze_flat" option is set, this will just return the input sky model.
-        Since the "flux is the same at all frequencies, there is no reason to copy it over. This can
-        prevent needless memory bloat.
-
         Parameters
         ----------
         freqs: Quantity
@@ -659,10 +650,6 @@ class SkyModel(UVBase):
         inplace: bool
             If True, modify the current SkyModel object.
             Otherwise, returns a new instance. Default True.
-        squeeze_flat: bool
-            If flat-spectrum, return the same flat-spectrum array.
-            This will avoid copying the Stokes array len(freqs) times.
-            Default False.
         freq_interp_kind: str or int
             Spline interpolation order, as can be understood by scipy.interpolate.interp1d.
             Defaults to 'cubic'
@@ -704,11 +691,6 @@ class SkyModel(UVBase):
             sky.stokes = finterp(freqs)
         else:
             # flat spectrum
-            if squeeze_flat:
-                sky.stokes = self.stokes
-                if not inplace:
-                    return sky
-                return
             sky.stokes = np.repeat(self.stokes, len(freqs), axis=1)
 
         sky.reference_frequency = None

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -7,7 +7,6 @@ import warnings
 
 import h5py
 import numpy as np
-import copy
 from scipy.linalg import orthogonal_procrustes as ortho_procr
 import scipy.io
 from astropy.coordinates import Angle, EarthLocation, AltAz, Latitude, Longitude
@@ -630,11 +629,11 @@ class SkyModel(UVBase):
 
         return equal
 
-    def evaluate_stokes(
+    def at_frequencies(
         self, freqs, inplace=True, freq_interp_kind="cubic", run_check=True,
     ):
         """
-        Evaluate the stokes array to specified frequencies.
+        Evaluate the stokes array at the specified frequencies.
 
         Produces a SkyModel object that is in the `full` frequency spectral type, based on
         the current spectral type:
@@ -662,7 +661,7 @@ class SkyModel(UVBase):
         if inplace:
             sky = self
         else:
-            sky = copy.deepcopy(self)
+            sky = self.copy()
 
         if self.spectral_type == "spectral_index":
             sky.stokes = (

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -9,7 +9,6 @@ import h5py
 import pytest
 import numpy as np
 import warnings
-import copy
 from astropy import units
 from astropy.coordinates import (
     SkyCoord,
@@ -1902,22 +1901,22 @@ def test_stokes_eval(mock_point_skies, inplace, stype):
     fine_spectrum = (fine_freqs / fine_freqs[0]) ** (alpha)
 
     sky = mock_point_skies(stype)
-    oldsky = copy.deepcopy(sky)
+    oldsky = sky.copy()
     old_freqs = oldsky.freq_array
     if stype == "full":
         with pytest.raises(ValueError, match="Some requested frequencies"):
-            sky.evaluate_stokes(fine_freqs, inplace=inplace)
-        new = sky.evaluate_stokes(old_freqs, inplace=inplace)
+            sky.at_frequencies(fine_freqs, inplace=inplace)
+        new = sky.at_frequencies(old_freqs, inplace=inplace)
         if inplace:
             new = sky
         assert np.allclose(new.freq_array, old_freqs)
-        new = sky.evaluate_stokes(old_freqs[5:10], inplace=inplace)
+        new = sky.at_frequencies(old_freqs[5:10], inplace=inplace)
         if inplace:
             new = sky
         assert np.allclose(new.freq_array, old_freqs[5:10])
     else:
         # Evaluate new frequencies, and confirm the new spectrum is correct.
-        new = sky.evaluate_stokes(fine_freqs, inplace=inplace)
+        new = sky.at_frequencies(fine_freqs, inplace=inplace)
         if inplace:
             new = sky
         assert np.allclose(new.freq_array, fine_freqs)
@@ -1929,4 +1928,4 @@ def test_stokes_eval(mock_point_skies, inplace, stype):
         if stype == "subband" and not inplace:
             # Check for error if interpolating outside the defined range.
             with pytest.raises(ValueError, match="A value in x_new is above"):
-                sky.evaluate_stokes(fine_freqs + 10 * units.Hz, inplace=inplace)
+                sky.at_frequencies(fine_freqs + 10 * units.Hz, inplace=inplace)

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1925,11 +1925,6 @@ def test_stokes_eval(mock_point_skies, inplace, stype):
 
         if stype != "flat":
             assert np.allclose(new.stokes[0, :, 0], fine_spectrum)
-        elif not inplace:
-            # Check squeeze_flat option
-            new_flat = sky.evaluate_stokes(fine_freqs, inplace=False, squeeze_flat=True)
-            assert np.all(new_flat.stokes == oldsky.stokes)
-            assert new_flat.spectral_type == "flat"
 
         if stype == "subband" and not inplace:
             # Check for error if interpolating outside the defined range.


### PR DESCRIPTION
Adds a new method to SkyModel that will evaluate the Stokes array at a given set of frequencies, depending on the spectral_type, returning a new SkyModel (or modifying in-place) which has spectral_type "full".

- If spectral_type is "full", check that the requested frequencies are a subset of the existing frequencies and select those. Otherwise, error.
- If spectral_type is "sub-band", interpolate using scipy.interpolate.interp1d (freq_interp_kind controls the order). Additional interpolation methods can be added in future work.
- If spectral_type is "spectral_index", evaluate at the new frequencies.
- If flat, return a "full" freq SkyModel with the fluxes copied Nfreqs times. (Not really useful, but included for completeness).

Closes #52 