### PR TITLE
rename `read_idl_catalog` to `read_fhd_catalog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and K based units.
 component types.
 
 ### Changed
+- Renamed the `read_idl_catalog` method to `read_fhd_catalog`.
 - The `stokes` and `coherency_radec` parameters are now Quantity objects and must
 have units of 'Jy' or 'K sr' if `component_type` is 'point' and 'Jy/sr' or 'K'
 if the `component_type` is 'healpix'.
@@ -17,6 +18,7 @@ must now be Quantity objects.
 - The utility function `jy_to_ksr` now uses astropy's built in conversion methods.
 
 ### Deprecated
+- The `read_idl_catalog` method.
 - Initializing a SkyModel object with a float array rather than a Quantity for
 `stokes` is deprecated and support will be removed in a future version.
 - Passing floats rather than Quantity objects as inputs to the

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2218,7 +2218,7 @@ class SkyModel(UVBase):
 
         return
 
-    def read_idl_catalog(
+    def read_fhd_catalog(
         self,
         filename_sav,
         expand_extended=True,
@@ -2228,7 +2228,9 @@ class SkyModel(UVBase):
         run_check_acceptability=True,
     ):
         """
-        Read in an FHD-readable IDL .sav file catalog.
+        Read in an FHD style catalog file.
+
+        FHD catalog files are IDL save files.
 
         Parameters
         ----------
@@ -2379,6 +2381,66 @@ class SkyModel(UVBase):
             )
 
         return
+
+    def read_idl_catalog(
+        self,
+        filename_sav,
+        expand_extended=True,
+        source_select_kwds=None,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
+    ):
+        """
+        Read in an FHD style catalog file.
+
+        Deprecated. Use `read_fhd_catalog` instead.
+
+        Parameters
+        ----------
+        filename_sav: str
+            Path to IDL .sav file.
+
+        expand_extended: bool
+            If True, return extended source components.
+            Default: True
+        source_select_kwds : dict, optional
+            Dictionary of keywords for source selection. Valid options:
+
+            * `lst_array`: For coarse RA horizon cuts, lsts used in the simulation [radians]
+            * `latitude_deg`: Latitude of telescope in degrees. Used for declination coarse
+            *  horizon cut.
+            * `horizon_buffer`: Angle (float, in radians) of buffer for coarse horizon cut.
+              Default is about 10 minutes of sky rotation. (See caveats in
+              :func:`array_to_skymodel` docstring)
+            * `min_flux`: Minimum stokes I flux to select [Jy]
+            * `max_flux`: Maximum stokes I flux to select [Jy]
+        run_check : bool
+            Option to check for the existence and proper shapes of parameters
+            after downselecting data on this object (the default is True,
+            meaning the check will be run).
+        check_extra : bool
+            Option to check optional parameters as well as required ones (the
+            default is True, meaning the optional parameters will be checked).
+        run_check_acceptability : bool
+            Option to check acceptable range of the values of parameters after
+            downselecting data on this object (the default is True, meaning the
+            acceptable range check will be done).
+
+
+        """
+        warnings.warn(
+            "This method is deprecated, use `read_fhd_catalog` instead.",
+            category=DeprecationWarning,
+        )
+        self.read_fhd_catalog(
+            filename_sav,
+            expand_extended=expand_extended,
+            source_select_kwds=source_select_kwds,
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
+        )
 
     def write_healpix_hdf5(self, filename):
         """
@@ -3011,7 +3073,7 @@ def read_idl_catalog(filename_sav, expand_extended=True):
     """
     Read in an FHD-readable IDL .sav file catalog.
 
-    Deprecated. Use `SkyModel.read_idl_catalog` instead.
+    Deprecated. Use `SkyModel.read_fhd_catalog` instead.
 
     Parameters
     ----------
@@ -3027,12 +3089,12 @@ def read_idl_catalog(filename_sav, expand_extended=True):
     :class:`pyradiosky.SkyModel`
     """
     warnings.warn(
-        "This function is deprecated, use `SkyModel.read_idl_catalog` instead.",
+        "This function is deprecated, use `SkyModel.read_fhd_catalog` instead.",
         category=DeprecationWarning,
     )
 
     skyobj = SkyModel()
-    skyobj.read_idl_catalog(
+    skyobj.read_fhd_catalog(
         filename_sav, expand_extended=expand_extended,
     )
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1855,43 +1855,52 @@ def test_read_votable_errors():
         )
 
 
-def test_idl_catalog_reader():
+def test_fhd_catalog_reader():
     catfile = os.path.join(SKY_DATA_PATH, "fhd_catalog.sav")
 
     skyobj = SkyModel()
-    skyobj.read_idl_catalog(catfile, expand_extended=False)
+    skyobj.read_fhd_catalog(catfile, expand_extended=False)
 
     catalog = scipy.io.readsav(catfile)["catalog"]
     assert skyobj.Ncomponents == len(catalog)
 
     with pytest.warns(
         DeprecationWarning,
-        match="This function is deprecated, use `SkyModel.read_idl_catalog` instead.",
+        match="This function is deprecated, use `SkyModel.read_fhd_catalog` instead.",
     ):
         skyobj2 = skymodel.read_idl_catalog(catfile, expand_extended=False)
 
     assert skyobj == skyobj2
 
+    skyobj3 = SkyModel()
+    with pytest.warns(
+        DeprecationWarning,
+        match="This method is deprecated, use `read_fhd_catalog` instead.",
+    ):
+        skyobj3.read_idl_catalog(catfile, expand_extended=False)
 
-def test_idl_catalog_reader_source_cuts():
+    assert skyobj == skyobj3
+
+
+def test_fhd_catalog_reader_source_cuts():
     catfile = os.path.join(SKY_DATA_PATH, "fhd_catalog.sav")
 
     skyobj = SkyModel()
-    skyobj.read_idl_catalog(catfile, expand_extended=False)
+    skyobj.read_fhd_catalog(catfile, expand_extended=False)
     skyobj.source_cuts(latitude_deg=30.0)
 
     skyobj2 = SkyModel()
-    skyobj2.read_idl_catalog(
+    skyobj2.read_fhd_catalog(
         catfile, expand_extended=False, source_select_kwds={"latitude_deg": 30.0}
     )
 
     assert skyobj == skyobj2
 
 
-def test_idl_catalog_reader_extended_sources():
+def test_fhd_catalog_reader_extended_sources():
     catfile = os.path.join(SKY_DATA_PATH, "fhd_catalog.sav")
     skyobj = SkyModel()
-    skyobj.read_idl_catalog(catfile, expand_extended=True)
+    skyobj.read_fhd_catalog(catfile, expand_extended=True)
 
     catalog = scipy.io.readsav(catfile)["catalog"]
     ext_inds = np.where(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rename method that reads FHD catalog files to better match what it does.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #71 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have added tests to cover any changes.
- [x] My change includes a breaking change
  - [x] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/master/CHANGELOG.md) if appropriate.
