### PR TITLE
Add classmethods to create SkyModel instances from different formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased]
 
 ### Added
-- A `from_xxx` classmethod for every `read_xxx` method, to enable instantiation from
-  different formats directly.
+- Classmethods `from_recarray`, `from_healpix_hdf5`, `from_votable_catalog`,
+  `from_text_catalog`, `from_gleam_catalog` and `from_idl_catalog` to enable
+  instantiation from different formats directly.
 
 ## [0.1.0] - 2020-6-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- A `from_xxx` classmethod for every `read_xxx` method, to enable instantiation from
+  different formats directly.
+
 ## [0.1.0] - 2020-6-29
 
 ### Added

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -1659,8 +1659,6 @@ class SkyModel(UVBase):
             spectral_index=spectral_index,
         )
 
-        # TODO: not sure if the following is really necessary if we're newly creating
-        # the full object
         if ids[0].startswith("nside"):
             self.nside = int(ids[0][len("nside") : ids[0].find("_")])
             self.hpx_inds = np.array([int(name[name.find("_") + 1 :]) for name in ids])
@@ -2128,7 +2126,10 @@ class SkyModel(UVBase):
             source_select_kwds=source_select_kwds,
         )
 
-        # TODO: checks not run here?
+        if run_check:
+            self.check(
+                check_extra=check_extra, run_check_acceptability=run_check_acceptability
+            )
         return
 
     @classmethod

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2949,10 +2949,7 @@ def array_to_skymodel(catalog_table):
         category=DeprecationWarning,
     )
 
-    skyobj = SkyModel()
-    skyobj.from_recarray(catalog_table)
-
-    return skyobj
+    return SkyModel.from_recarray(catalog_table)
 
 
 def source_cuts(
@@ -3006,8 +3003,7 @@ def source_cuts(
         category=DeprecationWarning,
     )
 
-    skyobj = SkyModel()
-    skyobj.from_recarray(catalog_table)
+    skyobj = SkyModel.from_recarray(catalog_table)
     skyobj.source_cuts(
         latitude_deg=latitude_deg,
         horizon_buffer=horizon_buffer,

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2501,24 +2501,6 @@ class SkyModel(UVBase):
 
         return
 
-    @classmethod
-    def from_idl_catalog(cls, filename_sav, **kwargs):
-        """Create a :class:`SkyModel` from a IDL catalog.
-
-        Parameters
-        ----------
-        kwargs :
-            All parameters are sent through to :meth:`read_idl_catalog`.
-
-        Returns
-        -------
-        sky_model : :class:`SkyModel`
-            The object instantiated using the IDL catalog.
-        """
-        self = cls()
-        self.read_idl_catalog(filename_sav, **kwargs)
-        return self
-
     def read_idl_catalog(
         self,
         filename_sav,

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -181,6 +181,7 @@ def mock_point_skies():
 
 @pytest.fixture(scope="function")
 def healpix_disk():
+    pytest.importorskip("astropy_healpix")
     return SkyModel.from_healpix_hdf5(os.path.join(SKY_DATA_PATH, "healpix_disk.hdf5"))
 
 
@@ -1988,8 +1989,6 @@ def test_text_catalog_loop_other_freqs(tmp_path, freq_mult):
 
 
 def test_write_text_catalog_error(tmp_path, healpix_disk):
-    pytest.importorskip("astropy_healpix")
-
     fname = os.path.join(tmp_path, "temp_cat.txt")
 
     with pytest.raises(

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1967,8 +1967,7 @@ def test_text_catalog_loop(tmp_path, spec_type):
         # again with flat & freq_array
         skyobj.freq_array = np.atleast_1d(np.unique(reference_frequency))
         arr = skyobj.to_recarray()
-        skyobj2 = SkyModel()
-        skyobj2.from_recarray(arr)
+        skyobj2 = SkyModel.from_recarray(arr)
 
         assert skyobj == skyobj2
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1828,7 +1828,8 @@ def test_fhd_catalog_reader():
         DeprecationWarning,
         match="This method is deprecated, use `read_fhd_catalog` instead.",
     ):
-        skyobj3 = SkyModel.from_idl_catalog(catfile, expand_extended=False)
+        skyobj3 = SkyModel()
+        skyobj3.from_idl_catalog(catfile, expand_extended=False)
 
     assert skyobj == skyobj3
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1275,8 +1275,7 @@ def test_array_to_skymodel_loop(spec_type):
         sky.spectral_type = "full"
 
     arr = sky.to_recarray()
-    sky2 = SkyModel()
-    sky2.from_recarray(arr)
+    sky2 = SkyModel.from_recarray(arr)
 
     assert sky == sky2
 
@@ -1285,8 +1284,7 @@ def test_array_to_skymodel_loop(spec_type):
         reference_frequency = sky.reference_frequency
         sky.reference_frequency = None
         arr = sky.to_recarray()
-        sky2 = SkyModel()
-        sky2.from_recarray(arr)
+        sky2 = SkyModel.from_recarray(arr)
 
         assert sky == sky2
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1829,7 +1829,7 @@ def test_fhd_catalog_reader():
         match="This method is deprecated, use `read_fhd_catalog` instead.",
     ):
         skyobj3 = SkyModel()
-        skyobj3.from_idl_catalog(catfile, expand_extended=False)
+        skyobj3.read_idl_catalog(catfile, expand_extended=False)
 
     assert skyobj == skyobj3
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a `from_xxx` *class*method for every `read_xxx` method existing on `SkyModel`, as well as changing `from_recarray` to a classmethod. This means that new objects can be created using the syntax

```
skyobj = SkyModel.from_gleam_catalog(fname)
```

Instead of the more laborious (and a little confusing)

```
skyobj = SkyModel()
skyobj.read_gleam_catalog(fname)
```

I changed all applicable instances of such reading in the tests to use the `from_xxx` classmethod. I did not remove the `read_xxx` methods, as that would break backwards compatibility, and I guess those might still be useful. I recommend thinking about whether these should be deprecated. 

Nothing in this PR should be backwards incompatible -- it merely adds new methods.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #87 

I think this is the more pythonic way to do things, it means one less line for users to write, and it is seen in lots of other projects.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->


### New Feature Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have added tests to cover my new feature.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).

