### PR TITLE
Fix the future equality checks for ra & dec to use astropy's Quantity allclose

### DIFF
--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -639,7 +639,9 @@ class SkyModel(UVBase):
         equal = super(SkyModel, self).__eq__(other, check_extra=check_extra)
 
         # Issue deprecation warning if ra/decs aren't close to future_angle_tol levels
-        if not np.allclose(self.ra, other.ra, rtol=0, atol=self.future_angle_tol):
+        if not units.quantity.allclose(
+            self.ra, other.ra, rtol=0, atol=self.future_angle_tol
+        ):
             warnings.warn(
                 "The _ra parameters are not within the future tolerance. "
                 f"Left is {self.ra}, right is {other.ra}. "
@@ -647,7 +649,9 @@ class SkyModel(UVBase):
                 category=DeprecationWarning,
             )
 
-        if not np.allclose(self.dec, other.dec, rtol=0, atol=self.future_angle_tol):
+        if not units.quantity.allclose(
+            self.dec, other.dec, rtol=0, atol=self.future_angle_tol
+        ):
             warnings.warn(
                 "The _dec parameters are not within the future tolerance. "
                 f"Left is {self.dec}, right is {other.dec}. "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use `units.quantity.allclose` in the future equality tests rather than numpy's allclose.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes an error seen in the tests for #91 that are unrelated to that PR's changes.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
