### PR TITLE
fix missed parameters in init, fix extended model group bug in read_fhd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   `from_text_catalog`, `from_gleam_catalog` and `from_idl_catalog` to enable
   instantiation from different formats directly.
 
+### Fixed
+- A bug in `Skymodel.__init__` that caused extended_model_group and beam_amps
+    to not be added to the object.
+
 ## [0.1.0] - 2020-6-29
 
 ### Added

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -150,9 +150,6 @@ class SkyModel(UVBase):
         nside parameter for HEALPix maps.
     hpx_inds : array_like of int
         Indices for HEALPix maps, only used if nside is set.
-    pos_tol : float
-        position tolerance in degrees, defaults to minimum float in numpy
-        position tolerance in degrees
     extended_model_group : array_like of int
         Identifier that groups components of an extended source model.
         -1 for point sources, shape (Ncomponents,).
@@ -175,7 +172,6 @@ class SkyModel(UVBase):
         spectral_index=None,
         nside=None,
         hpx_inds=None,
-        pos_tol=np.finfo(float).eps,
         extended_model_group=None,
         beam_amp=None,
         history=None,
@@ -510,6 +506,12 @@ class SkyModel(UVBase):
 
             if self.Ncomponents == 1:
                 self.stokes = self.stokes.reshape(4, self.Nfreqs, 1)
+
+            if extended_model_group is not None:
+                self.extended_model_group = extended_model_group
+
+            if beam_amp is not None:
+                self.beam_amp = beam_amp
 
             # Indices along the component axis, such that the source is polarized at any frequency.
             self._polarized = np.where(
@@ -2428,6 +2430,7 @@ class SkyModel(UVBase):
                     source_freqs = np.delete(source_freqs, ext)
                     spectral_index = np.delete(spectral_index, ext)
                     source_inds = np.delete(source_inds, ext)
+                    extended_model_group = np.delete(extended_model_group, ext)
                     # Add component information
                     src = catalog[ext]["extend"]
                     Ncomps = len(src)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed some missed parameters in `__init__` and a bug in `read_fhd_catalog` that was exposed by the init fixes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes # 89

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
