### PR TITLE
enable tolerance when selecting frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   instantiation from different formats directly.
 
 ### Fixed
+- Enabled subselecting to a given tolerance in at_frequencies (for `full` spectral type).
 - A bug in `Skymodel.__init__` that caused extended_model_group and beam_amps
     to not be added to the object.
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -2141,7 +2141,7 @@ def test_stokes_eval(mock_point_skies, inplace, stype):
 def test_atfreq_tol(tmpdir, mock_point_skies):
     # Test that the at_frequencies method still recognizes the equivalence of
     # frequencies after losing precision by writing to text file.
-    # (Issue #94)
+    # (Issue #82)
 
     sky = mock_point_skies("full")
     ofile = str(tmpdir.join("full_point.txt"))

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -2141,7 +2141,7 @@ def test_stokes_eval(mock_point_skies, inplace, stype):
 def test_atfreq_tol(tmpdir, mock_point_skies):
     # Test that the at_frequencies method still recognizes the equivalence of
     # frequencies after losing precision by writing to text file.
-    # (Issue #82)
+    # (Issue #94)
 
     sky = mock_point_skies("full")
     ofile = str(tmpdir.join("full_point.txt"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enables tolerance when comparing frequencies in the `at_frequencies` method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When running `at_frequencies` on a SkyModel with spectral type "full", at_frequencies will attempt to select the requested frequencies from the existing array. Currently, this is done using `numpy.isin`, which requires an exact match. These changes allow frequencies to match to some tolerance in the search, defaulting to 1 Hz but settable with a keyword.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #82 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
