### PR TITLE
Fix the Gleam download to ensure it gets all the needed columns

### DIFF
--- a/pyradiosky/tests/test_utils.py
+++ b/pyradiosky/tests/test_utils.py
@@ -79,7 +79,8 @@ def test_stokes_tofrom_coherency():
     )
 
 
-def test_download_gleam(tmp_path):
+@pytest.mark.parametrize("stype", ["subband", "spectral_index", "flat"])
+def test_download_gleam(tmp_path, stype):
     pytest.importorskip("astroquery")
 
     fname = "gleam_cat.vot"
@@ -88,19 +89,19 @@ def test_download_gleam(tmp_path):
     skyutils.download_gleam(path=tmp_path, filename=fname, row_limit=10)
 
     sky = SkyModel()
-    sky.read_gleam_catalog(filename)
+    sky.read_gleam_catalog(filename, spectral_type=stype)
     assert sky.Ncomponents == 10
 
     # check there's not an error if the file exists and overwrite is False
     # and that the file is not replaced
     skyutils.download_gleam(path=tmp_path, filename=fname, row_limit=5)
-    sky.read_gleam_catalog(filename)
+    sky.read_gleam_catalog(filename, spectral_type=stype)
     assert sky.Ncomponents == 10
 
     # check that the file is replaced if overwrite is True
     skyutils.download_gleam(path=tmp_path, filename=fname, row_limit=5, overwrite=True)
     sky2 = SkyModel()
-    sky2.read_gleam_catalog(filename)
+    sky2.read_gleam_catalog(filename, spectral_type=stype)
     assert sky2.Ncomponents == 5
 
 

--- a/pyradiosky/utils.py
+++ b/pyradiosky/utils.py
@@ -229,7 +229,7 @@ def download_gleam(path=".", filename="gleam.vot", overwrite=False, row_limit=No
         Vizier.ROW_LIMIT = -1
     else:
         Vizier.ROW_LIMIT = row_limit
-    Vizier.columns = [
+    desired_columns = [
         "GLEAM",
         "RAJ2000",
         "DEJ2000",
@@ -257,8 +257,18 @@ def download_gleam(path=".", filename="gleam.vot", overwrite=False, row_limit=No
         "Fint220",
         "Fint227",
     ]
+    # There is a bug that causes astroquery to only download the first 14-16 specified
+    # columns if you pass it a long list of columns.
+    # The workaround is to download all columns and then remove the ones we don't need.
+    # This is not ideal because it substantially increases the download time, but seems
+    # to be required for now.
+    Vizier.columns = ["all"]
     catname = "VIII/100/gleamegc"
     table = Vizier.get_catalogs(catname)[0]
+
+    columns_to_remove = list(set(table.colnames) - set(desired_columns))
+    table.remove_columns(columns_to_remove)
+
     table.write(opath, format="votable", overwrite=overwrite)
 
     print("GLEAM catalog downloaded and saved to " + opath)

--- a/scripts/download_gleam.py
+++ b/scripts/download_gleam.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#! /usr/bin/env python
 # Copyright (c) 2019 Radio Astronomy Software Group
 # Licensed under the 3-clause BSD License
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modify the GLEAM download utility to download all columns and the remove the ones that are not required to ensure that we get all the required columns. We weren't catching this with our unit tests because they use to only use the flat spectral type, which only required the first few columns. This PR adds testing with all the possible spectral types to ensure that all the columns are present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #105 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
