### PR TITLE
Update changelog for PR #106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   instantiation from different formats directly.
 
 ### Fixed
+- A bug in the `download_gleam` utility method that caused missing columns for the
+    `subband` spectral type
 - Enabled subselecting to a given tolerance in at_frequencies (for `full` spectral type).
 - A bug in `Skymodel.__init__` that caused extended_model_group and beam_amps
     to not be added to the object.

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - astropy
+  - astropy>=4.0,<4.2
   - numpy
   - h5py
   - scipy

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - astropy>=4.0
+  - astropy>=4.0,<4.2
   - astropy-healpix
   - astroquery
   - h5py


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I forgot to update the changelog for PR #106. This remedies that.
It also limits us to not use astropy 4.2 until np.shape() works on Time objects (see #108)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Documentation Change Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
