### PR TITLE
Change the default spectral_type for GLEAM to `subband`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   instantiation from different formats directly.
 
 ### Changed
+- Changed default `spectral_type` for `read_gleam_catalog` to `subband` rather than `flat`.
 - Changed `extended_model_group` in `read_fhd_catalog` to match the parent source name.
 
 ### Fixed

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2263,7 +2263,7 @@ class SkyModel(UVBase):
     def read_gleam_catalog(
         self,
         gleam_file,
-        spectral_type="flat",
+        spectral_type="subband",
         source_select_kwds=None,
         run_check=True,
         check_extra=True,
@@ -3458,7 +3458,7 @@ def read_votable_catalog(
 
 
 def read_gleam_catalog(
-    gleam_file, spectral_type="flat", source_select_kwds=None, return_table=False
+    gleam_file, spectral_type="subband", source_select_kwds=None, return_table=False
 ):
     """
     Create a SkyModel object from the GLEAM votable catalog.

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -2116,7 +2116,7 @@ def test_text_catalog_loop(tmp_path, spec_type):
 @pytest.mark.filterwarnings("ignore:recarray flux columns will no longer be labeled")
 @pytest.mark.parametrize("freq_mult", [1e-6, 1e-3, 1e3])
 def test_text_catalog_loop_other_freqs(tmp_path, freq_mult):
-    skyobj = SkyModel.from_gleam_catalog(GLEAM_vot)
+    skyobj = SkyModel.from_gleam_catalog(GLEAM_vot, spectral_type="flat")
     skyobj.freq_array = np.atleast_1d(np.unique(skyobj.reference_frequency) * freq_mult)
     skyobj.reference_frequency = None
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the default GLEAM spectral type from "flat" to "subband" which is a better default for science.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #103 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
