### PR TITLE
Unit test for jy_to_ksr function

### DIFF
--- a/pyradiosky/tests/test_utils.py
+++ b/pyradiosky/tests/test_utils.py
@@ -118,3 +118,19 @@ def test_astroquery_missing_error(tmp_path):
             match="The astroquery module required to use the download_gleam function.",
         ):
             skyutils.download_gleam(path=tmp_path, filename=fname, row_limit=10)
+
+
+def test_jy_to_ksr():
+    Nfreqs = 200
+    freqs = np.linspace(100, 200, Nfreqs) * units.MHz
+
+    def jy2ksr_nonastropy(freq_arr):
+        c_cmps = 29979245800.0  # cm/s
+        k_boltz = 1.380658e-16  # erg/K
+        lam = c_cmps / freq_arr.to_value("Hz")  # cm
+        return 1e-23 * lam ** 2 / (2 * k_boltz)
+
+    conv0 = skyutils.jy_to_ksr(freqs)
+    conv1 = jy2ksr_nonastropy(freqs) * units.K * units.sr / units.Jy
+
+    assert np.allclose(conv0, conv1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a unit test of `utils.jy_to_ksr` which compares the astropy-based calculation used by the utility function to a non-astropy equivalent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

There wasn't any test of this function before, and so an astropy-related error came up undetected.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).