### PR TITLE
Use pyuvdata 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Required:
 
 * astropy>=4.0
 * h5py
-* numpy>=1.15
+* numpy
 * scipy>1.0.1
-* pyuvdata
+* pyuvdata>=2.1.3
 * setuptools_scm
 
 Optional:

--- a/ci/docs.yaml
+++ b/ci/docs.yaml
@@ -13,5 +13,5 @@ dependencies:
   - pytest-cov
   - setuptools_scm
   - sphinx
-  - pyuvdata>=2.0.1
+  - pyuvdata>=2.1.3
   - pip

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -9,5 +9,5 @@ dependencies:
   - scipy
   - coverage
   - pytest-cov
-  - pyuvdata>=2.0.1
+  - pyuvdata>=2.1.3
   - setuptools_scm

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -8,5 +8,5 @@ dependencies:
   - h5py
   - scipy
   - pep517
-  - pyuvdata>=2.0.1
+  - pyuvdata>=2.1.3
   - setuptools_scm

--- a/ci/pyuvsim.yaml
+++ b/ci/pyuvsim.yaml
@@ -13,7 +13,7 @@ dependencies:
   - psutil
   - pytest
   - pytest-runner
-  - pyuvdata
+  - pyuvdata>=2.1.3
   - pyyaml
   - scipy
   - setuptools_scm

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - astropy>=4.0,<4.2
+  - astropy>=4.0
   - astropy-healpix
   - astroquery
   - h5py
@@ -13,7 +13,7 @@ dependencies:
   - coverage
   - pytest-cov
   - setuptools_scm
-  - pyuvdata>=2.0.1
+  - pyuvdata>=2.1.3
   - pip
   - pip:
       - lunarsky

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,7 +12,7 @@ dependencies:
   - pip
   - pypandoc
   - pytest-cov
-  - pyuvdata
+  - pyuvdata>=2.1.3
   - pyyaml
   - scipy
   - setuptools_scm

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -281,10 +281,7 @@ def test_skymodel_init_errors(zenith_skycoord):
     # Check error cases
     with pytest.raises(
         ValueError,
-        match=(
-            "UVParameter _ra is not the appropriate type. Is: float64. "
-            "Should be: <class 'astropy.coordinates.angles.Longitude'>"
-        ),
+        match=("UVParameter _ra is not the appropriate type."),
     ):
         SkyModel(
             name="icrs_zen",
@@ -296,10 +293,7 @@ def test_skymodel_init_errors(zenith_skycoord):
 
     with pytest.raises(
         ValueError,
-        match=(
-            "UVParameter _dec is not the appropriate type. Is: float64. "
-            "Should be: <class 'astropy.coordinates.angles.Latitude'>"
-        ),
+        match=("UVParameter _dec is not the appropriate type."),
     ):
         SkyModel(
             name="icrs_zen",

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ setup_args = {
     "use_scm_version": {"local_scheme": branch_scheme},
     "include_package_data": True,
     "install_requires": [
-        "numpy>=1.15",
+        "numpy",
         "scipy",
         "astropy>=4.0",
         "h5py",
-        "pyuvdata",
+        "pyuvdata>=2.1.3",
         "setuptools_scm",
     ],
     "extras_require": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Require pyuvdata >=2.1.3 to fix issues seen under astropy 4.2.
Also update warning checking for changes in pyuvdata warning messages.

I also removed our version requirement on numpy (used to be `>1.15.0`) because pyuvdata specifies `>1.18.0`, so the pyuvdata requirement seems sufficient.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #108 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Build/CI Change Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyuvdata/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme
