### PR TITLE
Improve handling for init params passed as lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changed `extended_model_group` in `read_fhd_catalog` to match the parent source name.
 
 ### Fixed
+- Improved handling of lists passed to `SkyModel.__init__`.
 - A bug in the `download_gleam` utility method that caused missing columns for the
     `subband` spectral type
 - Enabled subselecting to a given tolerance in at_frequencies (for `full` spectral type).

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -241,7 +241,7 @@ class SkyModel(UVBase):
         self._nside = UVParameter(
             "nside",
             description=desc,
-            expected_type=np.int,
+            expected_type=int,
             required=False,
         )
 
@@ -250,7 +250,7 @@ class SkyModel(UVBase):
             "hpx_inds",
             description=desc,
             form=("Ncomponents",),
-            expected_type=np.int,
+            expected_type=int,
             required=False,
         )
 
@@ -395,7 +395,7 @@ class SkyModel(UVBase):
         )
 
         # handle old parameter order
-        # (use to be: name, ra, dec, stokes, freq_array spectral_type)
+        # (use to be: name, ra, dec, stokes, freq_array, spectral_type)
         if isinstance(spectral_type, (np.ndarray, list, float, Quantity)):
             warnings.warn(
                 "The input parameters to SkyModel.__init__ have changed. Please "
@@ -406,8 +406,7 @@ class SkyModel(UVBase):
             spectral_type = freq_array
 
             if spectral_type == "flat" and np.unique(freqs_use).size == 1:
-                reference_frequency = np.zeros((self.Ncomponents), dtype=np.float)
-                reference_frequency.fill(freqs_use[0])
+                reference_frequency = np.full((self.Ncomponents), freqs_use[0])
                 freq_array = None
             else:
                 freq_array = freqs_use
@@ -1189,7 +1188,7 @@ class SkyModel(UVBase):
 
         R_avg = self._calc_average_rotation_matrix()
 
-        R_exact = np.zeros((3, 3, n_inds), dtype=np.float)
+        R_exact = np.zeros((3, 3, n_inds), dtype=np.float64)
 
         for src_i in range(n_inds):
             intermediate_vec = np.matmul(R_avg, radec_vec[:, src_i])
@@ -1230,7 +1229,7 @@ class SkyModel(UVBase):
         theta_altaz = np.pi / 2.0 - self.alt_az[0, inds]
         phi_altaz = self.alt_az[1, inds]
 
-        coherency_rot_matrix = np.zeros((2, 2, n_inds), dtype=np.float)
+        coherency_rot_matrix = np.zeros((2, 2, n_inds), dtype=np.float64)
         for src_i in range(n_inds):
             coherency_rot_matrix[
                 :, :, src_i

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -490,8 +490,7 @@ def test_init_lists_errors(spec_type, param, msg, zenith_skycoord):
     elif param == "stokes_hz":
         stokes = stokes.value * units.Hz
     elif param == "stokes_obj":
-        stokes = list(stokes)
-        stokes[1] = [icrs_coord] * 5
+        stokes = icrs_coord
 
     with pytest.raises(ValueError, match=msg):
         if list_warning is not None:

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -30,6 +30,9 @@ from pyradiosky import skymodel, SkyModel
 
 GLEAM_vot = os.path.join(SKY_DATA_PATH, "gleam_50srcs.vot")
 
+# ignore new numpy 1.20 warning emitted from h5py
+pytestmark = pytest.mark.filterwarnings("ignore:Passing None into shape arguments")
+
 
 @pytest.fixture
 def time_location():
@@ -288,7 +291,7 @@ def test_init_lists(spec_type, param, zenith_skycoord):
     ras = Longitude(
         [zenith_skycoord.ra + Longitude(0.5 * ind * units.deg) for ind in range(5)]
     )
-    decs = Latitude(np.zeros(5, dtype=np.float) + icrs_coord.dec.value * units.deg)
+    decs = Latitude(np.zeros(5, dtype=np.float64) + icrs_coord.dec.value * units.deg)
     names = ["src_" + str(ind) for ind in range(5)]
 
     if spec_type in ["subband", "full"]:
@@ -298,12 +301,12 @@ def test_init_lists(spec_type, param, zenith_skycoord):
         n_freqs = 1
         freq_array = None
 
-    stokes = np.zeros((4, n_freqs, 5), dtype=np.float) * units.Jy
+    stokes = np.zeros((4, n_freqs, 5), dtype=np.float64) * units.Jy
     stokes[0, :, :] = 1 * units.Jy
 
     if spec_type == "spectral_index":
-        ref_freqs = np.zeros(5, dtype=np.float) + 150e6 * units.Hz
-        spec_index = np.zeros(5, dtype=np.float) - 0.8
+        ref_freqs = np.zeros(5, dtype=np.float64) + 150e6 * units.Hz
+        spec_index = np.zeros(5, dtype=np.float64) - 0.8
     else:
         ref_freqs = None
         spec_index = None
@@ -421,7 +424,7 @@ def test_init_lists_errors(spec_type, param, msg, zenith_skycoord):
     ras = Longitude(
         [zenith_skycoord.ra + Longitude(0.5 * ind * units.deg) for ind in range(5)]
     )
-    decs = Latitude(np.zeros(5, dtype=np.float) + icrs_coord.dec.value * units.deg)
+    decs = Latitude(np.zeros(5, dtype=np.float64) + icrs_coord.dec.value * units.deg)
     names = ["src_" + str(ind) for ind in range(5)]
 
     if spec_type in ["subband", "full"]:
@@ -431,12 +434,12 @@ def test_init_lists_errors(spec_type, param, msg, zenith_skycoord):
         n_freqs = 1
         freq_array = None
 
-    stokes = np.zeros((4, n_freqs, 5), dtype=np.float) * units.Jy
+    stokes = np.zeros((4, n_freqs, 5), dtype=np.float64) * units.Jy
     stokes[0, :, :] = 1.0 * units.Jy
 
     if spec_type == "spectral_index":
-        ref_freqs = np.zeros(5, dtype=np.float) + 150e6 * units.Hz
-        spec_index = np.zeros(5, dtype=np.float) - 0.8
+        ref_freqs = np.zeros(5, dtype=np.float64) + 150e6 * units.Hz
+        spec_index = np.zeros(5, dtype=np.float64) - 0.8
     else:
         ref_freqs = None
         spec_index = None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Better handle lists of Quantities used to initialize a SkyModel object. This used to error with a very confusing error message. Now if the lists contain compatible Quantities it just works (except for the Stokes parameter which must be an array), otherwise it gives a more helpful error message.

I also fixed a few things to deal with new deprecation warnings in numpy 1.20.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #99 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
