### PR TITLE
Add healpix pixel ordering parameter hpx_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- Support for ring / nested healpix ordering.
 - New `SkyModel.concat` method to support concatenating catalogs.
 - A new optional parameters `stokes_error` to track errors on the fluxes reported by catalogs.
 
 ### Fixed
 - Some bugs related to writing & reading skyh5 files after converting object using `healpix_to_point` method.
+
 ## [0.1.1] - 2021-02-17
 
 ### Added

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -3789,7 +3789,7 @@ def write_healpix_hdf5(filename, hpmap, indices, freqs, nside=None, history=None
                 fileobj.attrs[k] = d
 
 
-def healpix_to_sky(hpmap, indices, freqs):
+def healpix_to_sky(hpmap, indices, freqs, hpx_order="ring"):
     """
     Convert a healpix map in K to a set of point source components in Jy.
 
@@ -3804,6 +3804,9 @@ def healpix_to_sky(hpmap, indices, freqs):
         Corresponding HEALPix indices for hpmap.
     freqs : array_like, float
         Frequencies in Hz. Shape (Nfreqs)
+    hpx_order : str
+        HEALPix map ordering parameter: ring or nested.
+        Defaults to ring.
 
     Returns
     -------
@@ -3827,10 +3830,13 @@ def healpix_to_sky(hpmap, indices, freqs):
         "This function will be removed in version 0.2.0.",
         category=DeprecationWarning,
     )
+    hpx_order = str(hpx_order).lower()
+    if hpx_order not in ["ring", "nested"]:
+        raise ValueError("order must be 'nested' or 'ring'")
 
     nside = int(astropy_healpix.npix_to_nside(hpmap.shape[-1]))
 
-    ra, dec = astropy_healpix.healpix_to_lonlat(indices, nside)
+    ra, dec = astropy_healpix.healpix_to_lonlat(indices, nside, order=hpx_order)
     freq = Quantity(freqs, "hertz")
 
     stokes = Quantity(np.zeros((4, len(freq), len(indices))), "K")
@@ -3844,6 +3850,7 @@ def healpix_to_sky(hpmap, indices, freqs):
         freq_array=freq,
         nside=nside,
         hpx_inds=indices,
+        hpx_order=hpx_order,
     )
     return sky
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -3087,6 +3087,7 @@ def test_healpix_hdf5_read_errors_newstyle_healpix():
 
 def test_hpx_ordering():
     # Setting the hpx_order parameter
+    pytest.importorskip("astropy_healpix")
     nside = 16
     npix = 12 * nside ** 2
     stokes = np.zeros((4, 1, npix)) * units.K

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1607,6 +1607,30 @@ def test_units_healpix_to_sky(healpix_data, healpix_disk_old):
     assert units.quantity.allclose(sky.stokes[0, 0], stokes[0])
 
 
+@pytest.mark.filterwarnings("ignore:This method reads an old 'healvis' style healpix")
+@pytest.mark.parametrize("hpx_order", ["none", "ring", "nested"])
+def test_order_healpix_to_sky(healpix_data, hpx_order):
+
+    inds = np.arange(healpix_data["npix"])
+    hmap_orig = np.zeros_like(inds)
+    hmap_orig[healpix_data["ipix_disc"]] = healpix_data["npix"] - 1
+    hmap_orig = np.repeat(hmap_orig[None, :], 10, axis=0)
+    with pytest.warns(
+        DeprecationWarning,
+        match="This function is deprecated, use `SkyModel.read_skyh5` or `SkyModel.read_healpix_hdf5` instead.",
+    ):
+        if hpx_order == "none":
+            with pytest.raises(ValueError, match="order must be 'nested' or 'ring'"):
+                sky = skymodel.healpix_to_sky(
+                    hmap_orig, inds, healpix_data["frequencies"], hpx_order=hpx_order
+                )
+        else:
+            sky = skymodel.healpix_to_sky(
+                hmap_orig, inds, healpix_data["frequencies"], hpx_order=hpx_order
+            )
+            assert sky.hpx_order == hpx_order
+
+
 @pytest.mark.filterwarnings("ignore:recarray flux columns will no longer be labeled")
 def test_healpix_recarray_loop(healpix_data, healpix_disk_new):
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -3059,3 +3059,36 @@ def test_skyh5_read_errors_oldstyle_healpix():
 def test_healpix_hdf5_read_errors_newstyle_healpix():
     with pytest.raises(ValueError, match="This is a skyh5 file"):
         SkyModel.from_healpix_hdf5(os.path.join(SKY_DATA_PATH, "healpix_disk.skyh5"))
+
+
+def test_hpx_ordering():
+    # Setting the hpx_order parameter
+    nside = 16
+    npix = 12 * nside ** 2
+    stokes = np.zeros((4, 1, npix)) * units.K
+
+    with pytest.raises(ValueError, match="order must be 'nested' or 'ring'"):
+        sky = SkyModel(
+            hpx_inds=np.arange(npix),
+            nside=nside,
+            hpx_order="none",
+            stokes=stokes,
+            spectral_type="flat",
+        )
+
+    sky = SkyModel(
+        hpx_inds=np.arange(npix),
+        nside=16,
+        hpx_order="Ring",
+        stokes=stokes,
+        spectral_type="flat",
+    )
+    assert sky.hpx_order == "ring"
+    sky = SkyModel(
+        hpx_inds=np.arange(npix),
+        nside=16,
+        hpx_order="NESTED",
+        stokes=stokes,
+        spectral_type="flat",
+    )
+    assert sky.hpx_order == "nested"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a new parameter "hpx_order" to indicate if healpix pixels are in ring or nested order.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users should be able to control and check what ordering is used. Currently , it quietly defaults to ring ordering.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #133 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->


### New Feature Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have added tests to cover my new feature.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).