### PR TITLE
SkyModel.name as array, not list, after healpix_to_point

### DIFF
--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -991,7 +991,7 @@ class SkyModel(UVBase):
             self.coherency_radec * astropy_healpix.nside_to_pixel_area(self.nside)
         )
         name_use = ["nside" + str(self.nside) + "_" + str(ind) for ind in self.hpx_inds]
-        self.name = name_use
+        self.name = np.array(name_use)
 
         if to_jy:
             self.kelvin_to_jansky()

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -938,6 +938,17 @@ def test_healpix_to_point_errors(zenith_skymodel):
         zenith_skymodel.point_to_healpix()
 
 
+def test_healpix_to_point_source_cuts(healpix_disk_new):
+    """
+    This tests that `self.name` is set as a numpy ndarray, not a list, in
+    `healpix_to_point`.  If `self.name` is a list the indexing in
+    `source_cuts` will raise a TypeError.
+    """
+    skyobj = healpix_disk_new
+    skyobj.healpix_to_point()
+    skyobj.source_cuts(max_flux=0.9 * skyobj.stokes[0].max())
+
+
 def test_update_position_errors(zenith_skymodel, time_location):
     time, array_location = time_location
     with pytest.raises(ValueError, match=("time must be an astropy Time object.")):


### PR DESCRIPTION
## Description
When converting a SkyModel object from a component type of healpix to point, `self.name` is set as a list.  If you attempt to use any select functions like `source_cuts` after calling `healpix_to_point`, a TypeError is raised because lists do not support the indexing used in `select`.  This issue is fixed by casting `self.name` to a numpy array in `healpix_to_point`.  This branch modifies one line in `healpix_to_point` and adds a test to `test_skymodel.py` (the name can be changed if need be, but I added a description of what the test is intended to check.)

## Motivation and Context
I think this is addressed above in the description?  Just a niche bug fix.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).

## Else
Should I update the CHANGELOG for this minor change?
