### PR TITLE
pin last release of codecov action since main branch is broken

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -91,7 +91,7 @@ jobs:
           # pytest --pyargs pyradiosky --cov=pyradiosky --cov-config=../.coveragerc --cov-report xml:../coverage.xml --junitxml=../test-reports/xunit.xml
           # cd ..
 
-      - uses: codecov/codecov-action@master
+      - uses: codecov/codecov-action@v1.5.2
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -139,7 +139,7 @@ jobs:
         run: |
           python -m pytest -v --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
 
-      - uses: codecov/codecov-action@master
+      - uses: codecov/codecov-action@v1.5.2
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required


### PR DESCRIPTION
pins the codecov github action at v1.5.2 until codecov/codecov-action#372 is resolved the master branch for the action is broken.
### Build/CI Change Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme