### PR TITLE
Fix handling of hpx_order throughout, improve future equality warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Added
 - Ability to overwrite default ra/dec when importing a healpix map
-- `clobbler` keyword to allow overwriting of skyh5 files
+- `clobber` keyword to allow overwriting of skyh5 files
 - Support for ring / nested healpix ordering.
 - New `SkyModel.concat` method to support concatenating catalogs.
 - A new optional parameters `stokes_error` to track errors on the fluxes reported by catalogs.
 
 ### Fixed
+- Fix bugs causing healpix ordering to not be round tripped properly.
 - Some bugs related to writing & reading skyh5 files after converting object using `healpix_to_point` method.
 
 ## [0.1.1] - 2021-02-17

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1852,6 +1852,7 @@ def test_healpix_import_err(zenith_skymodel):
 
         zenith_skymodel.nside = 32
         zenith_skymodel.hpx_inds = 0
+        zenith_skymodel.hpx_order = "ring"
         with pytest.raises(ImportError, match=errstr):
             zenith_skymodel.point_to_healpix()
 

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -744,8 +744,9 @@ def test_skymodel_deprecated(time_location):
     with pytest.warns(
         DeprecationWarning,
         match=(
-            "Future equality does not pass, probably because the frequencies "
-            "were not checked"
+            re.escape(
+                "Future equality does not pass, because parameters ['reference_frequency']"
+            )
         ),
     ):
         assert source_new == source_old
@@ -888,7 +889,8 @@ def test_jansky_to_kelvin_loop(spec_type):
     assert skyobj3 == skyobj2
 
 
-def test_jansky_to_kelvin_loop_healpix(healpix_data, healpix_disk_new):
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
+def test_jansky_to_kelvin_loop_healpix(healpix_disk_new):
     skyobj = healpix_disk_new
 
     stokes_expected = np.zeros_like(skyobj.stokes.value) * units.Jy / units.sr
@@ -934,7 +936,8 @@ def test_jansky_to_kelvin_errors(zenith_skymodel):
         zenith_skymodel.kelvin_to_jansky()
 
 
-def test_healpix_to_point_loop(healpix_data, healpix_disk_new):
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
+def test_healpix_to_point_loop(healpix_disk_new):
     skyobj = healpix_disk_new
 
     skyobj2 = skyobj.copy()
@@ -955,11 +958,12 @@ def test_healpix_to_point_errors(zenith_skymodel):
     with pytest.raises(
         ValueError,
         match="This method can only be called if component_type is 'point' and "
-        "the nside and hpx_inds parameters are set.",
+        "the nside, hpx_order and hpx_inds parameters are set.",
     ):
         zenith_skymodel.point_to_healpix()
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_healpix_to_point_source_cuts(healpix_disk_new):
     """
     This tests that `self.name` is set as a numpy ndarray, not a list, in
@@ -1306,6 +1310,7 @@ def test_polarized_source_smooth_visibilities():
         assert np.all(imag_stokes == 0)
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize(
     "comp_type, spec_type",
     [
@@ -1484,6 +1489,7 @@ def test_concat_optional_params(param):
     assert skyobj_new == skyobj_full
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize("comp_type", ["point", "healpix"])
 def test_concat_overlap_errors(comp_type, healpix_disk_new):
     if comp_type == "point":
@@ -1506,6 +1512,7 @@ def test_concat_overlap_errors(comp_type, healpix_disk_new):
         skyobj1.concat(skyobj2)
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_concat_compatibility_errors(healpix_disk_new, time_location):
     skyobj_gleam_subband = SkyModel.from_gleam_catalog(
         GLEAM_vot, spectral_type="subband"
@@ -1664,8 +1671,9 @@ def test_order_healpix_to_sky(healpix_data, hpx_order):
             assert sky.hpx_order == hpx_order
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.filterwarnings("ignore:recarray flux columns will no longer be labeled")
-def test_healpix_recarray_loop(healpix_data, healpix_disk_new):
+def test_healpix_recarray_loop(healpix_disk_new):
 
     skyobj = healpix_disk_new
     skyarr = skyobj.to_recarray()
@@ -2796,6 +2804,7 @@ def test_text_catalog_loop_other_freqs(tmp_path, freq_mult):
     assert skyobj == skyobj2
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_write_text_catalog_error(tmp_path, healpix_disk_new):
     fname = os.path.join(tmp_path, "temp_cat.txt")
 
@@ -3003,6 +3012,7 @@ def test_skyh5_file_loop_gleam(spec_type, tmpdir):
     assert sky2 == sky
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize("history", [None, "test"])
 def test_skyh5_file_loop_healpix(healpix_disk_new, history, tmpdir):
     sky = healpix_disk_new
@@ -3022,6 +3032,7 @@ def test_skyh5_file_loop_healpix(healpix_disk_new, history, tmpdir):
     assert sky2 == sky
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_skyh5_file_loop_healpix_cut_sky(healpix_disk_new, tmpdir):
     sky = healpix_disk_new
 
@@ -3036,6 +3047,7 @@ def test_skyh5_file_loop_healpix_cut_sky(healpix_disk_new, tmpdir):
     assert sky2 == sky
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_skyh5_file_loop_healpix_to_point(healpix_disk_new, tmpdir):
     sky = healpix_disk_new
 
@@ -3076,6 +3088,7 @@ def test_skyh5_read_errors(mock_point_skies, param, value, errormsg, tmpdir):
         SkyModel.from_skyh5(testfile)
 
 
+@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize(
     "param,value,errormsg",
     [
@@ -3125,7 +3138,9 @@ def test_hpx_ordering():
     npix = 12 * nside ** 2
     stokes = np.zeros((4, 1, npix)) * units.K
 
-    with pytest.raises(ValueError, match="order must be 'nested' or 'ring'"):
+    with pytest.raises(
+        ValueError, match=re.escape("hpx_order must be one of ['ring', 'nested']")
+    ):
         sky = SkyModel(
             hpx_inds=np.arange(npix),
             nside=nside,

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -220,7 +220,18 @@ def healpix_disk_old():
 @pytest.fixture(scope="function")
 def healpix_disk_new():
     pytest.importorskip("astropy_healpix")
-    return SkyModel.from_skyh5(os.path.join(SKY_DATA_PATH, "healpix_disk.skyh5"))
+
+    with uvtest.check_warnings(
+        UserWarning,
+        match=[
+            "Input ra and dec parameters are being used instead of the default",
+        ],
+    ):
+        sky = SkyModel.from_skyh5(os.path.join(SKY_DATA_PATH, "healpix_disk.skyh5"))
+
+    yield sky
+
+    del sky
 
 
 def test_set_spectral_params(zenith_skymodel):
@@ -889,7 +900,6 @@ def test_jansky_to_kelvin_loop(spec_type):
     assert skyobj3 == skyobj2
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_jansky_to_kelvin_loop_healpix(healpix_disk_new):
     skyobj = healpix_disk_new
 
@@ -936,7 +946,6 @@ def test_jansky_to_kelvin_errors(zenith_skymodel):
         zenith_skymodel.kelvin_to_jansky()
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_healpix_to_point_loop(healpix_disk_new):
     skyobj = healpix_disk_new
 
@@ -946,6 +955,18 @@ def test_healpix_to_point_loop(healpix_disk_new):
     skyobj2.point_to_healpix()
 
     assert skyobj == skyobj2
+
+
+def test_healpix_to_point_loop_ordering(healpix_disk_new):
+    skyobj = healpix_disk_new
+
+    skyobj2 = skyobj.copy()
+    skyobj2.hpx_order = "nested"
+    skyobj2.healpix_to_point()
+
+    skyobj2.point_to_healpix()
+
+    assert skyobj != skyobj2
 
 
 def test_healpix_to_point_errors(zenith_skymodel):
@@ -963,7 +984,6 @@ def test_healpix_to_point_errors(zenith_skymodel):
         zenith_skymodel.point_to_healpix()
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_healpix_to_point_source_cuts(healpix_disk_new):
     """
     This tests that `self.name` is set as a numpy ndarray, not a list, in
@@ -1310,7 +1330,6 @@ def test_polarized_source_smooth_visibilities():
         assert np.all(imag_stokes == 0)
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize(
     "comp_type, spec_type",
     [
@@ -1489,7 +1508,6 @@ def test_concat_optional_params(param):
     assert skyobj_new == skyobj_full
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize("comp_type", ["point", "healpix"])
 def test_concat_overlap_errors(comp_type, healpix_disk_new):
     if comp_type == "point":
@@ -1512,7 +1530,6 @@ def test_concat_overlap_errors(comp_type, healpix_disk_new):
         skyobj1.concat(skyobj2)
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_concat_compatibility_errors(healpix_disk_new, time_location):
     skyobj_gleam_subband = SkyModel.from_gleam_catalog(
         GLEAM_vot, spectral_type="subband"
@@ -1671,7 +1688,6 @@ def test_order_healpix_to_sky(healpix_data, hpx_order):
             assert sky.hpx_order == hpx_order
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.filterwarnings("ignore:recarray flux columns will no longer be labeled")
 def test_healpix_recarray_loop(healpix_disk_new):
 
@@ -2805,7 +2821,6 @@ def test_text_catalog_loop_other_freqs(tmp_path, freq_mult):
     assert skyobj == skyobj2
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_write_text_catalog_error(tmp_path, healpix_disk_new):
     fname = os.path.join(tmp_path, "temp_cat.txt")
 
@@ -3048,7 +3063,6 @@ def test_skyh5_file_loop_healpix_cut_sky(healpix_disk_new, tmpdir):
     assert sky2 == sky
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 def test_skyh5_file_loop_healpix_to_point(healpix_disk_new, tmpdir):
     sky = healpix_disk_new
 
@@ -3089,7 +3103,6 @@ def test_skyh5_read_errors(mock_point_skies, param, value, errormsg, tmpdir):
         SkyModel.from_skyh5(testfile)
 
 
-@pytest.mark.filterwarnings("ignore:Input ra and dec parameters are being used instead")
 @pytest.mark.parametrize(
     "param,value,errormsg",
     [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure that the `hpx_order` parameter is round tripped properly through the various conversion, read and write methods. Set it as a required parameter for healpix objects (this is backwards compatible because if it doesn't exist it is defaulted to 'ring' as it was being handled in the past).

Also improve the future equality warning which was very confusing and cleanup test warnings.
closes #140 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
We agreed in #134 to make hpx_order required for Healpix objects, but that was accidentally only implemented for the init function, not for the object. Since it wasn't required, we didn't notice that it wasn't being round tripped properly because when that happened it raised the future equality error which deceptively suggested the problem was to do with the frequency parameters rather than the hpx_order parameter.

In trying to clean up the test warnings, I fixed the future equality warning to clarify which parameters didn't match so that I could tell what was going on. That exposed this issue with hpx_order not being round tripped.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
