### PR TITLE
Improve the error message for initializing with wrong stokes shape

### DIFF
--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -4,8 +4,8 @@
 """Define SkyModel class and helper functions."""
 
 import warnings
-
 import os
+
 import h5py
 import numpy as np
 from scipy.linalg import orthogonal_procrustes as ortho_procr
@@ -15,15 +15,11 @@ from astropy.time import Time
 import astropy.units as units
 from astropy.units import Quantity
 from astropy.io import votable
+
 from pyuvdata.uvbase import UVBase
 from pyuvdata.parameter import UVParameter
 import pyuvdata.utils as uvutils
-
-try:
-    from pyuvdata.uvbeam.cst_beam import CSTBeam
-except ImportError:  # pragma: no cover
-    # backwards compatility for older pyuvdata versions
-    from pyuvdata.cst_beam import CSTBeam
+from pyuvdata.uvbeam.cst_beam import CSTBeam
 
 from . import utils as skyutils
 from . import spherical_coords_transforms as sct
@@ -446,7 +442,7 @@ class SkyModel(UVBase):
         # initialize the underlying UVBase properties
         super(SkyModel, self).__init__()
 
-        # String to add to history of any files written with this version of pyuvdata
+        # String to add to history of any files written with this version of pyradiosky
         self.pyradiosky_version_str = (
             "  Read/written with pyradiosky version: " + __version__ + "."
         )
@@ -712,6 +708,15 @@ class SkyModel(UVBase):
 
             if self.Ncomponents == 1:
                 self.stokes = self.stokes.reshape(4, self.Nfreqs, 1)
+
+            stokes_eshape = self._stokes.expected_shape(self)
+            if self.stokes.shape != stokes_eshape:
+                # Check this here to give a clear error. Otherwise this shape
+                # propagates to coherency_radec and gives a confusing error message.
+                raise ValueError(
+                    "stokes is not the correct shape. stokes shape is "
+                    f"{self.stokes.shape}, expected shape is {stokes_eshape}."
+                )
 
             if stokes_error is not None:
                 self.stokes_error = stokes_error

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -646,6 +646,16 @@ def test_skymodel_init_errors(zenith_skycoord):
             freq_array=[1e8] * units.Hz,
         )
 
+    with pytest.raises(ValueError, match=("stokes is not the correct shape.")):
+        SkyModel(
+            name=["icrs_zen0", "icrs_zen0", "icrs_zen0"],
+            ra=[ra] * 3,
+            dec=[dec] * 3,
+            stokes=[1.0, 0, 0, 0] * units.Jy,
+            spectral_type="flat",
+            freq_array=[1e8] * units.Hz,
+        )
+
     with pytest.raises(
         ValueError, match=("For point component types, the coherency_radec")
     ):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provide a better error message when SkyModel is initialized with a stokes array that is the incorrect shape (doesn't match the other input shapes)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #142 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
