### PR TITLE
Fix lat/lon access in source_cuts method

### DIFF
--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2765,12 +2765,16 @@ class SkyModel(UVBase):
             lat_rad = np.radians(latitude_deg)
             buff = horizon_buffer
 
-            tans = np.tan(lat_rad) * np.tan(skyobj.lat.rad)
+            lon, lat = skyobj.get_lon_lat()
+
+            tans = np.tan(lat_rad) * np.tan(lat.rad)
             nonrising = tans < -1
 
             comp_inds_to_keep = np.nonzero(~nonrising)[0]
             skyobj.select(component_inds=comp_inds_to_keep, run_check=False)
             tans = tans[~nonrising]
+
+            lon, lat = skyobj.get_lon_lat()
 
             with warnings.catch_warnings():
                 warnings.filterwarnings(
@@ -2778,8 +2782,8 @@ class SkyModel(UVBase):
                     message="invalid value encountered",
                     category=RuntimeWarning,
                 )
-                rise_lst = skyobj.lon.rad - np.arccos((-1) * tans) - buff
-                set_lst = skyobj.lon.rad + np.arccos((-1) * tans) + buff
+                rise_lst = lon.rad - np.arccos((-1) * tans) - buff
+                set_lst = lon.rad + np.arccos((-1) * tans) + buff
 
                 rise_lst[rise_lst < 0] += 2 * np.pi
                 set_lst[set_lst < 0] += 2 * np.pi

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -2445,6 +2445,15 @@ def test_select_none():
     assert skyobj2 == skyobj
 
 
+def test_source_cut_healpix(healpix_disk_new, time_location):
+    skyobj = healpix_disk_new
+
+    _, array_location = time_location
+
+    with uvtest.check_warnings(None):
+        skyobj.source_cuts(latitude_deg=array_location.lat.deg)
+
+
 @pytest.mark.filterwarnings("ignore:recarray flux columns will no longer be labeled")
 @pytest.mark.filterwarnings("ignore:The reference_frequency is aliased as `frequency`")
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the `get_lon_lat` method rather than directly accessing the attributes in the `source_cuts` method. Add a test that uses source_cuts on a healpix object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
The `source_cuts` method still directly accessed the log/lat attributes but those are not required to be set on Healpix objects. This causes a DeprecationWarning to be raised, which was missed because there was not a test of using that method on a healpix object.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
