### PR TITLE
fix `at_frequencies` interpolation if there are NaNs in the stokes array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- The `nan_handling` keyword to the `at_frequencies` method to control how NaNs in the
+stokes array on subband objects are handled during interpolation.
 - The `lat_range` and `lon_range` keywords to the `select` method to support selecting
 on fields.
 - The `min_brightness`, `max_brightness` and `brightness_freq_range` keywords to the
@@ -16,6 +18,10 @@ location, replacing functionality that was in the `source_cuts` method.
 and just returns the parameter values on point objects.
 - The `assign_to_healpix` method to assign point component objects to a healpix grid
 (using the nearest neighbor approach).
+
+### Fixed
+- A bug that caused the stokes array to be all NaNs after using the `at_frequencies`
+method on a subband spectral_type object if any NaNs appeared in the input stokes.
 
 ### Changed
 - `ra` and `dec` are no longer required parameters on healpix objects (since that

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -2041,9 +2041,12 @@ class SkyModel(UVBase):
                                 ]
 
                         if np.min(at_freq_arr) < np.min(freq_arr[freq_inds_use]):
-                            at_freq_inds_use = np.nonzero(
+                            at_freq_inds_use_low = np.nonzero(
                                 at_freq_arr >= np.min(freq_arr[freq_inds_use])
                             )[0]
+                            at_freq_inds_use = np.intersect1d(
+                                at_freq_inds_use, at_freq_inds_use_low
+                            )
                             at_freqs_small = np.nonzero(
                                 at_freq_arr < np.min(freq_arr[freq_inds_use])
                             )[0]

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -1917,12 +1917,14 @@ class SkyModel(UVBase):
             values and to set any values that are outside the range of non-NaN values to
             NaN, and "clip" to interpolate values using only the non-NaN values and to
             set any values that are outside the range of non-NaN values to the nearest
-            non-NaN value. Any sources that have all NaN values in the stokes array will
-            have NaN values in the output stokes. Note that the detection of NaNs is
-            done across all polarizations for each source, so all polarizations are
-            evaluated using the same set of frequencies (so a NaN in one polarization
-            at one frequency will cause that frequency to be excluded for the
-            interpolation of all the polarizations on that source).
+            non-NaN value. For both "interp" and "clip", any sources that have
+            too few non-Nan values to use the chosen `freq_interp_kind` will be
+            interpolated linearly and any sources that have all NaN values in the stokes
+            array will have NaN values in the output stokes. Note that the detection of
+            NaNs is done across all polarizations for each source, so all polarizations
+            are evaluated using the same set of frequencies (so a NaN in one
+            polarization at one frequency will cause that frequency to be excluded for
+            the interpolation of all the polarizations on that source).
         run_check: bool
             Run check on new SkyModel.
             Default True.

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -3741,6 +3741,8 @@ def test_at_frequencies_nan_handling(nan_handling):
     skyobj2.stokes[0, -2:, 2] = np.NaN  # no high freq support
     skyobj2.stokes[0, :, 3] = np.NaN  # all NaNs
     skyobj2.stokes[0, 1:-2, 4] = np.NaN  # only 2 good freqs
+    skyobj2.stokes[0, 0, 5] = np.NaN  # no low or high frequency support
+    skyobj2.stokes[0, -1, 5] = np.NaN  # no low or high frequency support
 
     message = ["Some stokes values are NaNs."]
     if nan_handling == "propagate":
@@ -3752,9 +3754,9 @@ def test_at_frequencies_nan_handling(nan_handling):
         message.extend(
             [
                 "1 components had all NaN stokes values. ",
-                "1 components had all NaN stokes values above one or more of the "
+                "2 components had all NaN stokes values above one or more of the "
                 "requested frequencies. ",
-                "1 components had all NaN stokes values below one or more of the "
+                "2 components had all NaN stokes values below one or more of the "
                 "requested frequencies. ",
                 "1 components had too few non-NaN stokes values for chosen "
                 "interpolation. Using linear interpolation for these components instead.",
@@ -3779,8 +3781,8 @@ def test_at_frequencies_nan_handling(nan_handling):
         )
 
     if nan_handling == "propagate":
-        assert np.all(np.isnan(skyobj2_interp.stokes[:, :, 0:5]))
-        assert np.all(~np.isnan(skyobj2_interp.stokes[:, :, 5:]))
+        assert np.all(np.isnan(skyobj2_interp.stokes[:, :, 0:6]))
+        assert np.all(~np.isnan(skyobj2_interp.stokes[:, :, 6:]))
     elif nan_handling == "interp":
         assert np.all(np.isnan(skyobj2_interp.stokes[:, 0, 0]))
         assert np.allclose(
@@ -3797,6 +3799,16 @@ def test_at_frequencies_nan_handling(nan_handling):
             atol=1e-5,
             rtol=0,
         )
+
+        assert np.all(np.isnan(skyobj2_interp.stokes[:, 0, 5]))
+        assert np.all(np.isnan(skyobj2_interp.stokes[:, 2, 5]))
+        assert np.allclose(
+            skyobj2_interp.stokes[:, 1, 2],
+            skyobj_interp.stokes[:, 1, 2],
+            atol=1e-5,
+            rtol=0,
+        )
+
     else:  # clip
         assert np.all(~np.isnan(skyobj2_interp.stokes[:, :, 0:3]))
 
@@ -3808,23 +3820,6 @@ def test_at_frequencies_nan_handling(nan_handling):
             rtol=0,
         )
 
-        assert np.all(~np.isnan(skyobj2_interp.stokes[:, :, 1]))
-        assert np.allclose(
-            skyobj2_interp.stokes[:, 0, 1], skyobj_interp.stokes[:, 0, 1]
-        )
-        assert np.allclose(
-            skyobj2_interp.stokes[:, 2, 1], skyobj_interp.stokes[:, 2, 1]
-        )
-        assert not np.allclose(
-            skyobj2_interp.stokes[:, 1, 1], skyobj_interp.stokes[:, 1, 1]
-        )
-        assert np.allclose(
-            skyobj2_interp.stokes[:, 1, 1],
-            skyobj_interp.stokes[:, 1, 1],
-            atol=1e-2,
-            rtol=0,
-        )
-
         assert np.allclose(skyobj2_interp.stokes[:, 2, 2], skyobj.stokes[:, -3, 2])
         assert np.allclose(
             skyobj2_interp.stokes[:, 0:-1, 2],
@@ -3833,7 +3828,14 @@ def test_at_frequencies_nan_handling(nan_handling):
             rtol=0,
         )
 
-        assert np.all(np.isnan(skyobj2_interp.stokes[:, :, 3]))
+        assert np.allclose(skyobj2_interp.stokes[:, 0, 5], skyobj.stokes[:, 1, 5])
+        assert np.allclose(skyobj2_interp.stokes[:, 2, 5], skyobj.stokes[:, -2, 5])
+        assert np.allclose(
+            skyobj2_interp.stokes[:, 1, 5],
+            skyobj_interp.stokes[:, 1, 5],
+            atol=1e-5,
+            rtol=0,
+        )
 
     if nan_handling in ["interp", "clip"]:
         assert np.all(np.isnan(skyobj2_interp.stokes[:, :, 3]))
@@ -3881,7 +3883,7 @@ def test_at_frequencies_nan_handling(nan_handling):
             rtol=0,
         )
 
-    assert np.allclose(skyobj2_interp.stokes[:, :, 5:], skyobj_interp.stokes[:, :, 5:])
+    assert np.allclose(skyobj2_interp.stokes[:, :, 6:], skyobj_interp.stokes[:, :, 6:])
 
 
 @pytest.mark.parametrize("nan_handling", ["propagate", "interp", "clip"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a bug where all the values in the output stokes array were NaN after calling `at_frequencies` on a subband object with some NaNs on a few sources in the stokes array.

Added the `nan_handling` keyword to the `at_frequencies` method to specify how NaNs in the stokes array are handled when interpolating subband spectral_type objects. These are handled per-component. Options are:
- "propagate": set all the output stokes to NaN if any input stokes are NaN
- "interp": interpolate using only the non-NaN values. If there are requested frequencies outside the non-NaN values for a source, set the stokes array at those frequencies to NaN.
- "clip": interpolate using only the non-NaN values. If there are requested frequencies outside the non-NaN values for a source, set the stokes array at those frequencies to the value at the nearest non-NaN frequency. (This is the default).

For all these choices, components with all NaN values in the input stokes array will have NaNs in the output stokes array. Also, if there are too few non-NaN values to do the chosen interpolation, a linear interpolation for that component will be done.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #164

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
