### PR TITLE
Improve handling of optional parameters in concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ healpix objects the `ra` and `dec` parameters are no longer populated.
 - `point_to_healpix` has been renamed to `_point_to_healpix` because it's only intended
 to be used internally to undo the `healpix_to_point` method.
 
+## Fixed
+- A bug in `concat` when optional spectral paramters are not None on one of the objects.
+
 ### Deprecated
 - The `source_cuts` method and the `source_select_kwds` keywords to the reading methods.
 - The `point_to_healpix` method.

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -1732,6 +1732,7 @@ def test_concat(comp_type, spec_type, healpix_disk_new):
         "lon",
         "lat",
         "name",
+        "spectral_index",
     ],
 )
 def test_concat_optional_params(param, healpix_disk_new):
@@ -1754,6 +1755,8 @@ def test_concat_optional_params(param, healpix_disk_new):
         skyobj_full.extended_model_group = skyobj_full.name
     elif param == "beam_amp":
         skyobj_full.beam_amp = np.ones((4, skyobj_full.Nfreqs, skyobj_full.Ncomponents))
+    elif param == "spectral_index":
+        skyobj_full.spectral_index = np.full((skyobj_full.Ncomponents), -0.7)
 
     assert getattr(skyobj_full, param) is not None
 
@@ -1781,7 +1784,7 @@ def test_concat_optional_params(param, healpix_disk_new):
     skyobj_new.history = skyobj_full.history
 
     assert getattr(skyobj_new, "_" + param) != getattr(skyobj_full, "_" + param)
-    if param == "reference_frequency":
+    if param in ["reference_frequency", "spectral_index"]:
         assert np.allclose(
             getattr(skyobj_new, param)[
                 skyobj_full.Ncomponents // 2 : skyobj_full.Ncomponents
@@ -1812,6 +1815,10 @@ def test_concat_optional_params(param, healpix_disk_new):
         assert np.isnan(
             getattr(skyobj_new, param)[: skyobj_full.Ncomponents // 2].value
         ).all()
+    elif param == "spectral_index":
+        assert np.isnan(
+            getattr(skyobj_new, param)[: skyobj_full.Ncomponents // 2]
+        ).all()
     elif param == "extended_model_group":
         assert np.all(getattr(skyobj_new, param)[: skyobj_full.Ncomponents // 2] == "")
     elif param not in ["lon", "lat", "name"]:
@@ -1836,7 +1843,7 @@ def test_concat_optional_params(param, healpix_disk_new):
     skyobj_new.history = skyobj_full.history
 
     assert getattr(skyobj_new, "_" + param) != getattr(skyobj_full, "_" + param)
-    if param == "reference_frequency":
+    if param in ["reference_frequency", "spectral_index"]:
         assert np.allclose(
             getattr(skyobj_new, param)[: skyobj_full.Ncomponents // 2],
             getattr(skyobj_full, param)[: skyobj_full.Ncomponents // 2],
@@ -1858,6 +1865,12 @@ def test_concat_optional_params(param, healpix_disk_new):
             getattr(skyobj_new, param)[
                 skyobj_full.Ncomponents // 2 : skyobj_full.Ncomponents
             ].value
+        ).all()
+    elif param == "spectral_index":
+        assert np.isnan(
+            getattr(skyobj_new, param)[
+                skyobj_full.Ncomponents // 2 : skyobj_full.Ncomponents
+            ]
         ).all()
     elif param == "extended_model_group":
         assert np.all(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug in `concat` when spectral type is not "spectral_index" but the spectral_index parameter is not None on at least one of the objects.

Restructured the handling of all optional parameters with an axis of length Ncomponents in `concat` to consolidate code and make it easier to add more such parameters in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #160 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
