### PR TITLE
Add a CI check for warnings in the test suite

### DIFF
--- a/.github/workflows/externaltests.yaml
+++ b/.github/workflows/externaltests.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-         fetch-depth: 0
+          fetch-depth: 0
 
       - name: clone pyuvsim
         run: |

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -66,6 +66,8 @@ jobs:
       PYTHON: 3.7
     name: Min Deps Testing
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     defaults:
       run:
         # Adding -l {0} helps ensure conda can be found properly.
@@ -120,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.0.0

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install .
+          pip install --no-deps .
 
       - name: Run Tests
         run: |
@@ -95,11 +95,58 @@ jobs:
 
       - name: Install
         run: |
-          pip install .
+          pip install --no-deps .
 
       - name: Run Tests
         run: |
           python -m pytest -v --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+
+      - uses: codecov/codecov-action@v2.0.2
+        if: success()
+        with:
+          token: ${{secrets.CODECOV_TOKEN}} #required
+          file: ./coverage.xml #optional
+
+  warning_test:
+    env:
+      ENV_NAME: tests
+      PYTHON: 3.8
+    name: Warning Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Adding -l {0} helps ensure conda can be found properly.
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          auto-update-conda: true
+          miniconda-version: "latest"
+          python-version: ${{ env.PYTHON }}
+          environment-file: ci/${{ env.ENV_NAME }}.yaml
+          activate-environment: ${{ env.ENV_NAME }}
+
+      - name: Conda Info
+        run: |
+          conda info -a
+          conda list
+          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+            exit 1;
+          fi
+
+      - name: Install
+        run: |
+          pip install --no-deps .
+
+      - name: Run Tests
+        run: |
+          python -m pytest -W error --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
 
       - uses: codecov/codecov-action@v2.0.2
         if: success()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a CI check that there are no unhandled warnings in the test suite. Similar to recently added warnings checks on pyuvdata and pyuvsim.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Build/CI Change Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme
