### PR TITLE
Add allowed_failures parameter to SkyModel.__eq__ to match UVBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ## Changed
+- Added support for `allowed_failures` keyword in `SkyModel.__eq__` to match
+`pyuvdata.UVBase`, update pyuvdata minimum version to 2.2.1 when that keyword was
+introduced.
 - Updated the astropy requirement to >= 5.0.4
 - Dropped support for python 3.7
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Required:
 * h5py
 * numpy
 * scipy>1.0.1
-* pyuvdata>=2.1.3
+* pyuvdata>=2.2.1
 * setuptools_scm
 
 Optional:

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -10,5 +10,5 @@ dependencies:
   - coverage
   - pytest
   - pytest-cov
-  - pyuvdata>=2.1.3
+  - pyuvdata>=2.2.1
   - setuptools_scm

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - h5py
   - scipy
-  - pyuvdata>=2.1.3
+  - pyuvdata>=2.2.1
   - setuptools_scm
   - pip
   - pip:

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -13,7 +13,7 @@ dependencies:
   - coverage
   - pytest-cov
   - setuptools_scm
-  - pyuvdata>=2.1.3
+  - pyuvdata>=2.2.1
   - pip
   - pip:
       - lunarsky

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pre-commit
   - pypandoc
   - pytest-cov
-  - pyuvdata>=2.1.3
+  - pyuvdata>=2.2.1
   - pyyaml
   - scipy
   - setuptools_scm

--- a/pyradiosky/skymodel.py
+++ b/pyradiosky/skymodel.py
@@ -998,14 +998,16 @@ class SkyModel(UVBase):
         # Error if attribute not found
         return self.__getattribute__(name)
 
-    def __eq__(self, other, check_extra=True):
+    def __eq__(self, other, check_extra=True, allowed_failures=None):
         """Check for equality, check for future equality."""
         # Run the basic __eq__ from UVBase
         # the filters below should be removed in version 0.3.0
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="lon is no longer")
             warnings.filterwarnings("ignore", message="lat is no longer")
-            equal = super(SkyModel, self).__eq__(other, check_extra=check_extra)
+            equal = super(SkyModel, self).__eq__(
+                other, check_extra=check_extra, allowed_failures=allowed_failures
+            )
 
             # Issue deprecation warning if ra/decs aren't close to future_angle_tol levels
             if self._lon.value is not None and not units.quantity.allclose(
@@ -2735,7 +2737,6 @@ class SkyModel(UVBase):
                 this.history += " Next object history follows. " + other.history
             else:
                 if "_combine_history_addition" in dir(uvutils):
-                    # this uses new (in v2.2.0) functionality in pyuvdata
                     extra_history = uvutils._combine_history_addition(
                         this.history, other.history
                     )
@@ -2744,13 +2745,6 @@ class SkyModel(UVBase):
                             " Unique part of next object history follows. "
                             + extra_history
                         )
-                else:  # pragma: no cover
-                    # backwards compatibility for older versions of pyuvdata
-                    # remove when we require pyuvdata>=2.2.0
-                    this.history = uvutils._combine_histories(
-                        this.history + " Unique part of next object history follows. ",
-                        other.history,
-                    )
 
         # Check final object is self-consistent
         if run_check:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup_args = {
         "scipy",
         "astropy>=5.0.4",
         "h5py",
-        "pyuvdata>=2.1.3",
+        "pyuvdata>=2.2.1",
         "setuptools_scm",
     ],
     "extras_require": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for the `allowed_failures` parameter in `SkyModel.__eq__` to match the parameter added to `pyuvdata.UVBase.__eq__` in version 2.2.1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
