### PR TITLE
fix tests for new pyuvdata updates, new astropy deprecation warnings

### DIFF
--- a/.github/workflows/externaltests.yaml
+++ b/.github/workflows/externaltests.yaml
@@ -1,6 +1,10 @@
 name: External Tests
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   pyuvsim:
     name: pyuvsim

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -2,6 +2,10 @@ name: Publish Python distributions to PyPI and TestPyPI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-n-publish:
     name: Build and publish to PyPI and TestPyPI

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -111,6 +111,57 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}} #required
           file: ./coverage.xml #optional
 
+  min_versions:
+    needs: tests
+    env:
+      ENV_NAME: min_versions
+      PYTHON: 3.8
+    name: Min Deps Testing
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    defaults:
+      run:
+        # Adding -l {0} helps ensure conda can be found properly.
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+
+      - name: Setup Minimamba
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          python-version: ${{ env.PYTHON }}
+          environment-file: ci/${{ env.ENV_NAME }}.yaml
+          activate-environment: ${{ env.ENV_NAME }}
+
+      - name: Conda Info
+        run: |
+          conda info -a
+          conda list
+          PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
+          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+            exit 1;
+          fi
+
+      - name: Install
+        run: |
+          pip install --no-deps .
+
+      - name: Run Tests
+        run: |
+          python -m pytest -v --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+
+      - uses: codecov/codecov-action@v2.0.2
+        if: success()
+        with:
+          token: ${{secrets.CODECOV_TOKEN}} #required
+          file: ./coverage.xml #optional
+
   warning_test:
     env:
       ENV_NAME: tests

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          python -m pytest -v --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+          python -m pytest --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
 
       - uses: codecov/codecov-action@v2.0.2
         if: success()
@@ -116,7 +116,7 @@ jobs:
           file: ./coverage.xml #optional
 
   min_versions:
-    # needs: tests
+    needs: tests
     env:
       ENV_NAME: min_versions
       PYTHON: 3.8
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          python -m pytest -v --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+          python -m pytest --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
 
       - uses: codecov/codecov-action@v2.0.2
         if: success()
@@ -210,7 +210,10 @@ jobs:
 
       - name: Run Tests
         run: |
-          python -m pytest -W error --cov=pyradiosky --cov-config=.coveragerc --cov-report xml:./coverage.xml --junitxml=test-reports/xunit.xml
+          mkdir -p empty
+          cd empty
+          python -m pytest -W error --pyargs pyradiosky --cov=pyradiosky --cov-config=../.coveragerc --cov-report xml:.././coverage.xml --junitxml=../test-reports/xunit.xml
+          cd ..
 
       - uses: codecov/codecov-action@v2.0.2
         if: success()

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -210,9 +210,10 @@ jobs:
 
       - name: Run Tests
         run: |
+          mkdir test-reports
           mkdir -p empty
           cd empty
-          python -m pytest -W error --pyargs pyradiosky --cov=pyradiosky --cov-config=../.coveragerc --cov-report xml:.././coverage.xml --junitxml=../test-reports/xunit.xml
+          python -m pytest -W error --pyargs pyradiosky --cov=pyradiosky --cov-config="../.coveragerc" --cov-report xml:".././coverage.xml" --junitxml="../test-reports/xunit.xml"
           cd ..
 
       - uses: codecov/codecov-action@v2.0.2

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -116,12 +116,16 @@ jobs:
           file: ./coverage.xml #optional
 
   min_versions:
-    needs: tests
+    # needs: tests
     env:
       ENV_NAME: min_versions
       PYTHON: 3.8
     name: Min Versions Testing
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+      # should go to ubuntu instead when we require at least pyuvdata 2.2.4
+      # there are no linux packages on conda forge between 2.1.15 and 2.2.4 for some
+      # reason
+    # runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     defaults:

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -1,6 +1,10 @@
 name: Tests
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     env:
@@ -116,7 +120,7 @@ jobs:
     env:
       ENV_NAME: min_versions
       PYTHON: 3.8
-    name: Min Deps Testing
+    name: Min Versions Testing
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -7,7 +7,8 @@ dependencies:
   - astropy-healpix==0.6
   - astroquery==0.4.4
   - h5py==3.1.*
-  - numpy==1.19.*
+  # should be 1.19.* but the old packages of pyuvdata accidentally required 1.21
+  - numpy==1.21.*
   - scipy==1.3.*
   - coverage
   - pytest-cov

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -1,0 +1,18 @@
+name: min_versions
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - astropy==5.0.4
+  - astropy-healpix==0.6
+  - astroquery==0.4.4
+  - h5py==3.1.*
+  - numpy==1.19.*
+  - scipy==1.3.*
+  - coverage
+  - pytest-cov
+  - setuptools_scm==7.0.3
+  - pyuvdata==2.2.1
+  - pip
+  - pip:
+      - lunarsky==0.1.2

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -4,16 +4,15 @@ channels:
   - defaults
 dependencies:
   - astropy>=5.0.4
-  - astropy-healpix
-  - astroquery
-  - h5py
-  - numpy
-  - h5py
-  - scipy
+  - astropy-healpix>=0.6
+  - astroquery>=0.4.4
+  - h5py>=3.0
+  - numpy>=1.19.*
+  - scipy>=1.3
   - coverage
   - pytest-cov
-  - setuptools_scm
+  - setuptools_scm>=7.0.3
   - pyuvdata>=2.2.1
   - pip
   - pip:
-      - lunarsky
+      - lunarsky>=0.1.2

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -937,8 +937,8 @@ b) spectral index spectral type
   >>> plt.show() # doctest: +SKIP
 
   >>> sm.at_frequencies(freqs=[200*10**6]*units.Hz, inplace=True, run_check=True, atol=None)
-  >>> print(sm.stokes[0,0,8235])
-  0.5330077352813429 Jy
+  >>> print(f"{sm.stokes[0,0,8235]:.4f}")
+  0.5330 Jy
 
 .. image:: Images/fhd_catalog_refflux_nonzerospec.png
     :width: 600

--- a/pyradiosky/tests/test_skymodel.py
+++ b/pyradiosky/tests/test_skymodel.py
@@ -90,7 +90,14 @@ def moonsky():
         location=array_location,
     )
 
-    icrs_coord = zen_coord.transform_to("icrs")
+    # This filter can be removed when lunarsky is updated to not trigger this
+    # astropy deprecation warning.
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="The get_frame_attr_names",
+        )
+        icrs_coord = zen_coord.transform_to("icrs")
 
     ra = icrs_coord.ra
     dec = icrs_coord.dec
@@ -116,8 +123,8 @@ def healpix_data():
     frequencies = np.linspace(100, 110, 10)
     pixel_area = astropy_healpix.nside_to_pixel_area(nside)
 
-    # Note that the cone search includes any pixels that overlap with the search
-    # region. With such a low resolution, this returns some slightly different
+    # Note that the cone search includes any pixels that overlap with the search region.
+    # With such a low resolution, this returns some slightly different
     # results from the equivalent healpy search. Subtracting(0.75 * pixres) from
     # the pixel area resolves this discrepancy for the test.
 
@@ -4371,6 +4378,9 @@ def test_skymodel_init_galactic_warning():
         )
 
 
+# This filter can be removed when lunarsky is updated to not trigger this
+# astropy deprecation warning.
+@pytest.mark.filterwarnings("ignore:The get_frame_attr_names")
 def test_skymodel_transform_unsupported_frame(zenith_skymodel):
     with pytest.raises(
         ValueError, match="Supplied frame GCRS is not supported at this time."
@@ -4378,6 +4388,9 @@ def test_skymodel_transform_unsupported_frame(zenith_skymodel):
         zenith_skymodel.transform_to("gcrs")
 
 
+# This filter can be removed when lunarsky is updated to not trigger this
+# astropy deprecation warning.
+@pytest.mark.filterwarnings("ignore:The get_frame_attr_names")
 def test_skymodel_tranform_frame(zenith_skymodel, zenith_skycoord):
     zenith_skymodel.transform_to("galactic")
     zenith_skycoord = zenith_skycoord.transform_to("galactic")
@@ -4387,6 +4400,9 @@ def test_skymodel_tranform_frame(zenith_skymodel, zenith_skycoord):
     assert units.allclose(zenith_skymodel.gb, zenith_skycoord.b)
 
 
+# This filter can be removed when lunarsky is updated to not trigger this
+# astropy deprecation warning.
+@pytest.mark.filterwarnings("ignore:The get_frame_attr_names")
 def test_skymodel_tranform_frame_roundtrip(zenith_skymodel, zenith_skycoord):
     original_sky = copy.deepcopy(zenith_skymodel)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tests were broken by a recent change to UVBase in pyuvdata and by a new astropy deprecation warning being triggered in lunarsky (I just filtered those for now, they need to be fixed in lunarsky). I also add a min versions CI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
