### PR TITLE
fix new pre-commit errors from flake8-bugbear

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -453,10 +453,10 @@ b) creating and writing out point catalog, using calculate_rise_set_lsts and cle
   >>> sm.update_positions(time, array_location)
 
   >>> sm.calculate_rise_set_lsts(array_location.lat)
-  >>> print(sm._rise_lst)
-  [1.16240067]
-  >>> print(sm._set_lst)
-  [5.11057854]
+  >>> print(np.array_str(sm._rise_lst, precision=7))
+  [1.1624007]
+  >>> print(np.array_str(sm._set_lst, precision=7))
+  [5.1105785]
 
   >>> # coherency in local alt/az basis can be different from coherency in ra/dec basis
   >>> print(sm.coherency_calc()[:,:,0,0])
@@ -467,13 +467,12 @@ b) creating and writing out point catalog, using calculate_rise_set_lsts and cle
   2015-03-01 00:00:00.000
   >>> print(sm.telescope_location)
   (5109342.76037543, 2005241.90402741, -3239939.46926403) m
-  >>> print(sm.alt_az)
-  [[1.57079633]
-   [1.72876609]]
-  >>> print(sm.pos_lmn)
-  [[ 2.12981215e-13]
-   [-3.39272742e-14]
-   [ 1.00000000e+00]]
+  >>> # only print the altitude, since it's close to zenith the azimuth is ill defined
+  >>> print(np.array_str(sm.alt_az[0], precision=7))
+  [1.5707963]
+  >>> # only print the n part, since it's close to zenith the l & m are ill defined
+  >>> print(np.array_str(sm.pos_lmn[2], precision=7))
+  [1.]
   >>> print(sm.above_horizon)
   [ True]
   >>> sm.clear_time_position_specific_params()

--- a/pyradiosky/tests/test_utils.py
+++ b/pyradiosky/tests/test_utils.py
@@ -9,8 +9,8 @@ import pytest
 from astropy.coordinates import Angle
 from astropy.time import Time
 
-import pyradiosky.utils as skyutils
 from pyradiosky import SkyModel
+from pyradiosky import utils as skyutils
 
 
 def test_tee_ra_loop():


### PR DESCRIPTION
pytest.raises should only be called on one line of code.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix some new pre-commit errors, mostly related to a new check in flake8-bugbear that flags `pytest.raises` calls that contain more than one line of code. Also work around an annoying isort error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
