### PR TITLE
fix make_flat_spectrum_eor.py not accepting a frame

### DIFF
--- a/scripts/make_flat_spectrum_eor.py
+++ b/scripts/make_flat_spectrum_eor.py
@@ -116,7 +116,7 @@ def flat_spectrum_skymodel(
         nside=nside,
         stokes=stokes * units.K,
         history=history_string,
-        frame=frame
+        frame=frame,
     )
 
 
@@ -159,7 +159,10 @@ if __name__ == "__main__":
         "--fname", type=str, help="Output file name", default="noise_sky.hdf5"
     )
     parser.add_argument(
-        "--frame", type=str, help="Astropy Frame for output SkyModel, default ICRS", default="icrs"
+        "--frame",
+        type=str,
+        help="Astropy Frame for output SkyModel, default ICRS",
+        default="icrs",
     )
 
     args = parser.parse_args()
@@ -180,7 +183,9 @@ if __name__ == "__main__":
         f" and variance {var} K^2 at channel {args.ref_chan}."
     )
 
-    sky = flat_spectrum_skymodel(var, nside, freqs=freq_array, ref_chan=args.ref_chan, frame=frame)
+    sky = flat_spectrum_skymodel(
+        var, nside, freqs=freq_array, ref_chan=args.ref_chan, frame=frame
+    )
     sky.check()
     print(sky.history)
     print(f"Saving to {fname}.")

--- a/scripts/make_flat_spectrum_eor.py
+++ b/scripts/make_flat_spectrum_eor.py
@@ -15,7 +15,7 @@ f21 = 1.420405751e9
 
 
 def flat_spectrum_skymodel(
-    variance, nside, ref_chan=0, ref_zbin=0, redshifts=None, freqs=None
+    variance, nside, ref_chan=0, ref_zbin=0, redshifts=None, freqs=None, frame="icrs"
 ):
     """
     Generate a full-frequency SkyModel of a flat-spectrum (noiselike) EoR signal.
@@ -116,6 +116,7 @@ def flat_spectrum_skymodel(
         nside=nside,
         stokes=stokes * units.K,
         history=history_string,
+        frame=frame
     )
 
 
@@ -157,11 +158,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--fname", type=str, help="Output file name", default="noise_sky.hdf5"
     )
+    parser.add_argument(
+        "--frame", type=str, help="Astropy Frame for output SkyModel, default ICRS", default="icrs"
+    )
 
     args = parser.parse_args()
 
     var = args.variance
     nside = args.nside
+    frame = args.frame
 
     fname = args.fname
     start_freq = args.start_freq
@@ -175,7 +180,7 @@ if __name__ == "__main__":
         f" and variance {var} K^2 at channel {args.ref_chan}."
     )
 
-    sky = flat_spectrum_skymodel(var, nside, freqs=freq_array, ref_chan=args.ref_chan)
+    sky = flat_spectrum_skymodel(var, nside, freqs=freq_array, ref_chan=args.ref_chan, frame=frame)
     sky.check()
     print(sky.history)
     print(f"Saving to {fname}.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
make_flat_spectrum_eor.py now accepts a coordinate frame to be input. If a frame is not specified, it defaults to ICRS.

## Motivation and Context
Previously, make_flat_spectrum_eor.py expected a frame to be specified for its returned SkyModel, but could not accept one as input. 
[<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/issues/210)


### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).

