### PR TITLE
Add `extra_columns` attribute to store other per-component catalog info

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -271,4 +271,4 @@ jobs:
         - name: Run Tests
           run: |
             cd docs
-            python -m pytest --doctest-glob="*.rst"
+            python -m pytest --doctest-glob="*.rst" -W "error::DeprecationWarning"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added an `extra_columns` attribute to SkyModel, a recarray to store other catalog
 information with a value per component.
 - Updated the pyuvdata requirement to >= 2.4.1
+- Updated the scipy requirement to >= 1.5
 
 ## [0.3.0] - 2023-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Updated the pyuvdata requirement to >= 2.4.1
+
 ## [0.3.0] - 2023-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Changed
+- Added an `extra_columns` attribute to SkyModel, a recarray to store other catalog
+information with a value per component.
 - Updated the pyuvdata requirement to >= 2.4.1
 
 ## [0.3.0] - 2023-04-10

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Required:
 * astropy>=5.2
 * h5py>=3.1
 * numpy>=1.20
-* scipy>=1.3
+* scipy>=1.5
 * pyuvdata>=2.4.1
 * setuptools_scm>=7.0.3
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Required:
 * h5py>=3.1
 * numpy>=1.20
 * scipy>=1.3
-* pyuvdata>=2.2.10
+* pyuvdata>=2.4.1
 * setuptools_scm>=7.0.3
 
 Optional:

--- a/ci/full_deps.yaml
+++ b/ci/full_deps.yaml
@@ -11,7 +11,7 @@ dependencies:
   - pip
   - pytest-cov
   - pyuvdata>=2.4.1
-  - scipy>=1.3
+  - scipy>=1.5
   - setuptools_scm>=7.0.3
   - pip:
       - lunarsky>=0.2.1

--- a/ci/full_deps.yaml
+++ b/ci/full_deps.yaml
@@ -10,7 +10,7 @@ dependencies:
   - numpy>=1.20
   - pip
   - pytest-cov
-  - pyuvdata>=2.2.10
+  - pyuvdata>=2.4.1
   - scipy>=1.3
   - setuptools_scm>=7.0.3
   - pip:

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -9,6 +9,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pyuvdata>=2.4.1
-  - scipy>=1.3
+  - scipy>=1.5
   - setuptools_scm>=7.0.3
   - pip

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -8,7 +8,7 @@ dependencies:
   - numpy>=1.20
   - pytest
   - pytest-cov
-  - pyuvdata>=2.2.10
+  - pyuvdata>=2.4.1
   - scipy>=1.3
   - setuptools_scm>=7.0.3
   - pip

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -12,7 +12,7 @@ dependencies:
   - coverage
   - pytest-cov
   - setuptools_scm==7.0.3
-  - pyuvdata==2.2.10
+  - pyuvdata==2.4.1
   - pip
   - pip:
       - lunarsky==0.2.1

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -6,8 +6,8 @@ dependencies:
   - astropy-healpix==0.6
   - astroquery==0.4.4
   - h5py==3.1.*
-  # should be 1.20.* but the old packages of pyuvdata accidentally required 1.21
-  - numpy==1.21.*
+  # should be 1.20.* but the old packages of pyuvdata accidentally required 1.23
+  - numpy==1.23.*
   - scipy==1.3.*
   - coverage
   - pytest-cov

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -8,7 +8,7 @@ dependencies:
   - h5py==3.1.*
   # should be 1.20.* but the old packages of pyuvdata accidentally required 1.23
   - numpy==1.23.*
-  - scipy==1.3.*
+  - scipy==1.5.*
   - coverage
   - pytest-cov
   - setuptools_scm==7.0.3

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -6,7 +6,7 @@ dependencies:
   - h5py>=3.0
   - numpy>=1.20
   - pip
-  - pyuvdata>=2.2.10
+  - pyuvdata>=2.4.1
   - scipy>=1.3
   - setuptools_scm>=7.0.3
   - pip:

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -7,7 +7,7 @@ dependencies:
   - numpy>=1.20
   - pip
   - pyuvdata>=2.4.1
-  - scipy>=1.3
+  - scipy>=1.5
   - setuptools_scm>=7.0.3
   - pip:
     - build

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -490,6 +490,7 @@ b) creating and writing out point catalog, using calculate_rise_set_lsts and cle
   ...     print(param)
   _above_horizon
   _extended_model_group
+  _extra_columns
   _hpx_inds
   _name
   _reference_frequency

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,7 +1,6 @@
 name: pyradiosky
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - astropy>=5.2
   - astropy-healpix>=0.6
@@ -13,7 +12,7 @@ dependencies:
   - pre-commit
   - pypandoc
   - pytest-cov
-  - pyuvdata>=2.2.10
+  - pyuvdata>=2.4.1
   - pyyaml
   - scipy>=1.3
   - setuptools_scm>=7.0.3

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest-cov
   - pyuvdata>=2.4.1
   - pyyaml
-  - scipy>=1.3
+  - scipy>=1.5
   - setuptools_scm>=7.0.3
   - sphinx
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=61", "wheel", "setuptools_scm>=7.0.3"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup_args = {
     "include_package_data": True,
     "install_requires": [
         "numpy>=1.20",
-        "scipy>=1.3",
+        "scipy>=1.5",
         "astropy>=5.2",
         "h5py>=3.1",
         "pyuvdata>=2.4.1",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_args = {
         "scipy>=1.3",
         "astropy>=5.2",
         "h5py>=3.1",
-        "pyuvdata>=2.2.10",
+        "pyuvdata>=2.4.1",
         "setuptools_scm>=7.0.3",
     ],
     "extras_require": {

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -1144,13 +1144,14 @@ class SkyModel(UVBase):
             values = [values]
         if len(names) != len(values):
             raise ValueError("Must provide the same number of names and values.")
-        if dtype is not None and not isinstance(dtype, (list, tuple, np.ndarray)):
-            if len(names) == 1:
+        if dtype is not None:
+            if isinstance(dtype, (list, tuple, np.ndarray)):
+                if len(dtype) != len(names):
+                    raise ValueError(
+                        "If dtype is set, it must be the same length as `name`."
+                    )
+            else:
                 dtype = [dtype]
-            if len(names) != len(values):
-                raise ValueError(
-                    "If dtype is set, it must be the same length as `name`."
-                )
         for val in values:
             if val.shape != (self.Ncomponents,):
                 raise ValueError(
@@ -2736,7 +2737,7 @@ class SkyModel(UVBase):
                     "combine objects."
                 )
             if set(this.extra_columns.dtype.names) != set(
-                this.extra_columns.dtype.names
+                other.extra_columns.dtype.names
             ):
                 raise ValueError(
                     "Both objects have extra_columns but the column names do not "
@@ -2744,7 +2745,7 @@ class SkyModel(UVBase):
                 )
             for name in this.extra_columns.dtype.names:
                 this_dtype = this.extra_columns.dtype[name].type
-                other_dtype = this.extra_columns.dtype[name].type
+                other_dtype = other.extra_columns.dtype[name].type
                 if this_dtype != other_dtype:
                     raise ValueError(
                         "Both objects have extra_columns but the dtypes for column "

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -10,6 +10,7 @@ import warnings
 import astropy.units as units
 import h5py
 import numpy as np
+import pyuvdata.utils as uvutils
 import scipy.io
 from astropy.coordinates import (
     AltAz,
@@ -25,19 +26,10 @@ from astropy.coordinates import frame_transform_graph
 from astropy.io import votable
 from astropy.time import Time
 from astropy.units import Quantity
+from pyuvdata.parameter import SkyCoordParameter, UVParameter
+from pyuvdata.uvbase import UVBase
+from pyuvdata.uvbeam.cst_beam import CSTBeam
 from scipy.linalg import orthogonal_procrustes as ortho_procr
-
-with warnings.catch_warnings():
-    # This filter can be removed when we require pyuvdata>=2.3
-    # is updated to use importlib.metadata rather than pkg_resources
-    warnings.filterwarnings(
-        "ignore", "Deprecated call to `pkg_resources.declare_namespace"
-    )
-    warnings.filterwarnings("ignore", "pkg_resources is deprecated as an API")
-    import pyuvdata.utils as uvutils
-    from pyuvdata.parameter import SkyCoordParameter, UVParameter
-    from pyuvdata.uvbase import UVBase
-    from pyuvdata.uvbeam.cst_beam import CSTBeam
 
 from . import __version__
 from . import spherical_coords_transforms as sct
@@ -1279,20 +1271,12 @@ class SkyModel(UVBase):
     ):
         """Check for equality, check for future equality."""
         # Run the basic __eq__ from UVBase
-        # the filters below should be removed when we require pyuvdata>=2.3
-        with warnings.catch_warnings():
-            try:
-                # The `silent` parameter was added in pyuvdata between 2.2.12 and 2.3
-                equal = super(SkyModel, self).__eq__(
-                    other,
-                    check_extra=check_extra,
-                    allowed_failures=allowed_failures,
-                    silent=silent,
-                )
-            except TypeError:
-                equal = super(SkyModel, self).__eq__(
-                    other, check_extra=check_extra, allowed_failures=allowed_failures
-                )
+        equal = super(SkyModel, self).__eq__(
+            other,
+            check_extra=check_extra,
+            allowed_failures=allowed_failures,
+            silent=silent,
+        )
 
         return equal
 

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -946,7 +946,10 @@ def test_extra_columns_errors():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("value array(s) must be 1D, Ncomponents length array(s)"),
+        match=re.escape(
+            "value array(s) must be 1D, Ncomponents length array(s). The "
+            "value array in index 0 is not the right shape."
+        ),
     ):
         skyobj.add_extra_columns(
             names="foo", values=np.arange(skyobj.Ncomponents - 1, dtype=float)
@@ -1945,8 +1948,12 @@ def test_concat_compatibility_errors(healpix_disk_new, time_location):
     )
     with pytest.raises(
         ValueError,
-        match="Both objects have extra_columns but the column names do not match. "
-        "Cannot combine objects.",
+        match=re.escape(
+            "Both objects have extra_columns but the column names do not match. Cannot "
+            "combine objects. Left object columns are: ('foo', 'bar', 'gah'). Right "
+            "object columns are: ('blech', 'bar', 'gah'). Unmatched columns are "
+            "{'foo'}"
+        ),
     ):
         skyobj1.concat(skyobj2)
     skyobj2 = skyobj_gleam_subband.select(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new SkyModel attribute, `extra_columns`, which is a recarray and can support additional per-component info.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #126

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### New Feature Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
