### PR TITLE
Fix serial concats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- An error when Skymodel.concat was called serially.
+
+
 ## [1.0.0] - 2024-05-09
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
     "numpy>=1.23",
     "pyuvdata>=2.4.3",
     "scipy>=1.7.3",
-    "setuptools>=61",
-    "setuptools_scm>=7.0.3",
+    "setuptools>=64",
+    "setuptools_scm>=8",
 ]
 requires-python = ">=3.10"
 keywords = ["radio astronomy"]

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -20,9 +20,8 @@ from astropy.coordinates import (
     Latitude,
     Longitude,
     SkyCoord,
+    frame_transform_graph,
 )
-from astropy.coordinates import concatenate as sc_concatenate
-from astropy.coordinates import frame_transform_graph
 from astropy.io import votable
 from astropy.time import Time
 from astropy.units import Quantity
@@ -2791,9 +2790,7 @@ class SkyModel(UVBase):
                 param_name = this_param.name
                 if this_param.value is not None and other_param.value is not None:
                     if param == "_skycoord":
-                        final_val = sc_concatenate(
-                            (this_param.value, other_param.value)
-                        )
+                        final_val = SkyCoord([this_param.value, other_param.value])
                     else:
                         final_val = np.concatenate(
                             (this_param.value, other_param.value)
@@ -2806,7 +2803,7 @@ class SkyModel(UVBase):
                     )
                     setattr(this, param_name, None)
         else:
-            this.skycoord = sc_concatenate((this.skycoord, other.skycoord))
+            this.skycoord = SkyCoord([this.skycoord, other.skycoord])
 
         this.stokes = np.concatenate((this.stokes, other.stokes), axis=2)
 

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -1603,14 +1603,23 @@ def test_concat(comp_type, spec_type, healpix_disk_new):
         dtype=[float, int, str],
     )
     skyobj1 = skyobj_full.select(
-        component_inds=np.arange(skyobj_full.Ncomponents // 2), inplace=False
+        component_inds=np.arange(skyobj_full.Ncomponents // 3), inplace=False
     )
     skyobj2 = skyobj_full.select(
-        component_inds=np.arange(skyobj_full.Ncomponents // 2, skyobj_full.Ncomponents),
+        component_inds=np.arange(
+            skyobj_full.Ncomponents // 3, 2 * skyobj_full.Ncomponents // 3
+        ),
+        inplace=False,
+    )
+    skyobj3 = skyobj_full.select(
+        component_inds=np.arange(
+            2 * skyobj_full.Ncomponents // 3, skyobj_full.Ncomponents
+        ),
         inplace=False,
     )
 
     skyobj_new = skyobj1.concat(skyobj2, inplace=False)
+    skyobj_new.concat(skyobj3)
     # check that filename not duplicated if its the same on both objects
     assert skyobj_new.filename == [filebasename]
 
@@ -1618,6 +1627,7 @@ def test_concat(comp_type, spec_type, healpix_disk_new):
     expected_history = (
         skyobj_full.history
         + "  Downselected to specific components using pyradiosky."
+        + " Combined skymodels along the component axis using pyradiosky."
         + " Combined skymodels along the component axis using pyradiosky."
     )
     assert uvutils._check_histories(skyobj_new.history, expected_history)
@@ -1638,11 +1648,14 @@ def test_concat(comp_type, spec_type, healpix_disk_new):
         )
     else:
         skyobj2.history += " " + skyobj2.pyradiosky_version_str
+    expected_history += " Combined skymodels along the component axis using pyradiosky."
     skyobj_new = skyobj1.concat(skyobj2, inplace=False, run_check=False)
+    skyobj_new.concat(skyobj3)
     assert skyobj_new.history != skyobj_full.history
     assert uvutils._check_histories(skyobj_new.history, expected_history)
 
     skyobj_new = skyobj1.concat(skyobj2, inplace=False, verbose_history=True)
+    skyobj_new.concat(skyobj3, verbose_history=True)
     assert skyobj_new.history != skyobj_full.history
     expected_history = (
         skyobj_full.history
@@ -1650,6 +1663,9 @@ def test_concat(comp_type, spec_type, healpix_disk_new):
         + " Combined skymodels along the component axis using pyradiosky. "
         + "Next object history follows. "
         + skyobj2.history
+        + " Combined skymodels along the component axis using pyradiosky. "
+        + "Next object history follows. "
+        + skyobj3.history
     )
     assert uvutils._check_histories(skyobj_new.history, expected_history)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Serial concatenation currently fails because `astropy.coordinates.concatenate` fails with serial concatenation. This PR removes the call to `concatenate` and just passes a list of SkyCoord objects to the SkyCoord constructor, which doesn't error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #245 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
