### PR TITLE
Use the new pyuvdata analytic short dipole beam in our polarized source test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- Use the new pyuvdata analytic short dipole beam for polarized source testing.
+- Updated minimum dependency versions: pyuvdata>=3.1.0
+- Updated minimum optional dependency versions: lunarsky>=0.2.5
+
 ## [1.0.1] - 2024-07-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ Required:
 * h5py>=3.4
 * numpy>=1.23
 * scipy>=1.8
-* pyuvdata>=2.4.3
+* pyuvdata>=3.1.0
 * setuptools_scm>=8.1
 
 Optional:
 
 * astropy-healpix>=1.0.2 (for working with beams in HEALPix formats)
 * astroquery>=0.4.4 (for downloading GLEAM and other VizieR catalogs)
-* lunarsky>=0.2.2 (for supporting telescope locations on the moon)
+* lunarsky>=0.2.5 (for supporting telescope locations on the moon)
 
 We suggest using conda to install all the dependencies. To install
 pyuvdata, astropy-healpix and astroquery, you'll need to add conda-forge as a channel

--- a/ci/full_deps.yaml
+++ b/ci/full_deps.yaml
@@ -11,8 +11,8 @@ dependencies:
   - numpy>=1.23
   - pip
   - pytest-cov
-  - pyuvdata>=2.4.3
+  - pyuvdata>=3.1.0
   - scipy>=1.8
   - setuptools_scm>=8.1
   - pip:
-      - lunarsky>=0.2.2
+      - lunarsky>=0.2.5

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -8,7 +8,7 @@ dependencies:
   - numpy>=1.23
   - pytest
   - pytest-cov
-  - pyuvdata>=2.4.3
+  - pyuvdata>=3.1.0
   - scipy>=1.8
   - setuptools_scm>=8.1
   - pip

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -11,7 +11,7 @@ dependencies:
   - coverage
   - pytest-cov
   - setuptools_scm==8.1
-  - pyuvdata==2.4.3
+  - pyuvdata==3.1.1  # 3.1.0 is not available on conda
   - pip
   - pip:
-      - lunarsky==0.2.2
+      - lunarsky==0.2.5

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -6,7 +6,7 @@ dependencies:
   - h5py>=3.4
   - numpy>=1.23
   - pip
-  - pyuvdata>=2.4.3
+  - pyuvdata>=3.1.0
   - scipy>=1.8
   - setuptools_scm>=8.1
   - pip:

--- a/docs/references/skyh5_memo.tex
+++ b/docs/references/skyh5_memo.tex
@@ -35,7 +35,7 @@ and optional elements and the structure of this file format, called \textit{SkyH
 We assume that the user has a working knowledge of HDF5 and the associated
 python bindings in the package \texttt{h5py}\footnote{\url{https://www.h5py.org/}}, as
 well as \texttt{SkyModel} objects in \texttt{pyradiosky}. For more information about
-HDF5, pleasevisit \url{https://portal.hdfgroup.org/display/HDF5/HDF5}. For more
+HDF5, please visit \url{https://portal.hdfgroup.org/display/HDF5/HDF5}. For more
 information about the parameters present in a \texttt{SkyModel} object, please visit
 \url{https://pyradiosky.readthedocs.io/en/latest/skymodel.html}.
 Examples of how to interact with \texttt{SkyModel} objects in \texttt{pyradiosky} are

--- a/environment.yaml
+++ b/environment.yaml
@@ -13,9 +13,9 @@ dependencies:
   - pre-commit
   - pypandoc
   - pytest-cov
-  - pyuvdata>=2.4.3
+  - pyuvdata>=3.1.0
   - scipy>=1.8
   - setuptools_scm>=8.1
   - sphinx
   - pip:
-      - lunarsky>=0.2.2
+      - lunarsky>=0.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "astropy>=6.0",
     "h5py>=3.4",
     "numpy>=1.23",
-    "pyuvdata>=2.4.3",
+    "pyuvdata>=3.1.0",
     "scipy>=1.8",
     "setuptools>=64",
     "setuptools_scm>=8.1",
@@ -42,7 +42,7 @@ classifiers = [
 [project.optional-dependencies]
 healpix = ["astropy-healpix>=1.0.2"]
 astroquery = ["astroquery>=0.4.4"]
-lunarsky = ["lunarsky>=0.2.2"]
+lunarsky = ["lunarsky>=0.2.5"]
 all = ["pyradiosky[healpix,astroquery,lunarsky]"]
 test = ["coverage", "pre-commit", "pytest", "pytest-cov"]
 doc = ["matplotlib", "pypandoc", "sphinx"]

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -9,6 +9,8 @@ import warnings
 import astropy.units as units
 import h5py
 import numpy as np
+import pyuvdata.utils.history as history_utils
+import pyuvdata.utils.tools as uvutils
 import scipy.io
 from astropy.coordinates import (
     AltAz,
@@ -29,15 +31,6 @@ from pyuvdata.uvbeam.cst_beam import CSTBeam
 from scipy.linalg import orthogonal_procrustes as ortho_procr
 
 from . import __version__, spherical_coords_transforms as sct, utils as skyutils
-
-try:  # pragma: no cover  # This pragma can be removed once pyuvdata v3 is released.
-    import pyuvdata.utils.history as history_utils
-    import pyuvdata.utils.tools as uvutils
-except ImportError:
-    # this can be removed once we require pyuvdata >= v3.0
-    import pyuvdata.utils as history_utils
-    import pyuvdata.utils as uvutils
-
 
 __all__ = ["hasmoon", "SkyModel"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the ad hoc analytic short dipole used in our testing of polarized sources with the pyuvdata analytic short dipole beam.

This requires bumping the minimum pyuvdata version to v3.1.0.

I also bumped the minimum lunarsky version to 0.2.5 for compatibility with astropy 6.0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
