### PR TITLE
Add option to skip optional params on read.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- An option to skip optional parameters when reading in skyh5 files.
+
 ### Changed
 - Use the new pyuvdata analytic short dipole beam for polarized source testing.
 - Updated minimum dependency versions: pyuvdata>=3.1.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ napoleon_custom_sections = [
     ("GLEAM", "params_style"),
     ("FHD", "params_style"),
     ("VOTable", "params_style"),
+    ("SkyH5", "params_style")
 ]
 
 # turn off alphabetical ordering in autodoc

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -3386,7 +3386,12 @@ class SkyModel(UVBase):
         return arr
 
     def read_skyh5(
-        self, filename, run_check=True, check_extra=True, run_check_acceptability=True
+        self,
+        filename: str,
+        skip_params: list[str] | None = None,
+        run_check: bool = True,
+        check_extra: bool = True,
+        run_check_acceptability: bool = True,
     ):
         """
         Read a skyh5 file (our flavor of hdf5) into this object.
@@ -3395,6 +3400,9 @@ class SkyModel(UVBase):
         ----------
         filename : str
             Path and name of the skyh5 file to read.
+        skip_params : list of str or bool
+            A list of optional parameters to skip on read. If set to True, skip
+            all optional parameters.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object (the default is True,
@@ -3509,6 +3517,12 @@ class SkyModel(UVBase):
                         copy=True
                     )
 
+            if isinstance(skip_params, bool) or skip_params is None:
+                if skip_params:
+                    skip_params = optional_params
+                else:
+                    skip_params = []
+
             for par in header_params:
                 if par in ["lat", "lon", "frame", "ra", "dec"]:
                     parname = par
@@ -3524,8 +3538,10 @@ class SkyModel(UVBase):
                     else:
                         str_type = False
 
-                # skip optional params if not present
-                if par in optional_params and parname not in header:
+                # skip optional params if not present or if in skip params
+                if par in optional_params and (
+                    parname in skip_params or parname not in header
+                ):
                     continue
 
                 if parname not in header:

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -3405,7 +3405,9 @@ class SkyModel(UVBase):
         skip_params : str or list of str or bool
             A list of optional parameters to skip on read. If set to True, skip
             all truly optional parameters. The default is False, so by default all
-            optional parameters will be read.
+            optional parameters will be read. Note that this only applies to
+            truly optional parameters that are saved in the file, any optional
+            parameters not saved in the file are always skipped.
         run_check : bool
             Option to check for the existence and proper shapes of parameters
             after downselecting data on this object (the default is True,
@@ -4575,7 +4577,9 @@ class SkyModel(UVBase):
         skip_params : str or list of str or bool
             A list of optional parameters to skip on read. If set to True, skip
             all optional parameters. The default is False, so by default all
-            optional parameters will be read.
+            optional parameters will be read. Note that this only applies to
+            truly optional parameters that are saved in the file, any optional
+            parameters not saved in the file are always skipped.
 
         VOTable
         -------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add option to skip reading optional params from skyH5 files, e.g. names for Healpix files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #266 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### New Feature Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
