### PR TITLE
Add option to select components with non-nan stokes values and non-negative stokes I values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [Unreleased]
 
 ### Added
-- New option to `SkyModel.select` to select components with no NaNs in their
-Stokes values.
+- New option to `SkyModel.select` to select components that do not have NaN
+values in the `stokes` parameter at either any or all frequencies.
 - New option to `SkyModel.select` to select components with no negative Stokes I
 values.
 - New check warnings about NaN stokes and spectral index values and negative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Added
+- New option to `SkyModel.select` to select components with no NaNs in their
+Stokes values.
+- New option to `SkyModel.select` to select components with no negative Stokes I
+values.
+- New check warnings about NaN stokes and spectral index values and negative
+Stokes I values.
 - An option to skip optional parameters when reading in skyh5 files.
 
 ### Changed
@@ -13,6 +19,9 @@ approach.
 - Use the new pyuvdata analytic short dipole beam for polarized source testing.
 - Updated minimum dependency versions: pyuvdata>=3.1.0
 - Updated minimum optional dependency versions: lunarsky>=0.2.5
+
+### Fixed
+- A bug where running check on read was impossible to turn off.
 
 ## [1.0.1] - 2024-07-01
 

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -478,6 +478,9 @@ class SkyModel(UVBase):
         extra_column_dict=None,
         history="",
         filename=None,
+        run_check=True,
+        check_extra=True,
+        run_check_acceptability=True,
     ):
         # standard angle tolerance: 1 mas in radians.
         self.angle_tol = Angle(1e-3, units.arcsec)
@@ -1051,7 +1054,11 @@ class SkyModel(UVBase):
             ):
                 self.history += self.pyradiosky_version_str
 
-            self.check()
+            if run_check:
+                self.check(
+                    check_extra=check_extra,
+                    run_check_acceptability=run_check_acceptability,
+                )
 
     def __getattr__(self, name):
         """Handle references to frame coordinates (ra/dec/gl/gb, etc.)."""
@@ -3655,12 +3662,12 @@ class SkyModel(UVBase):
             )
             init_params["frame"] = "icrs"
 
-        self.__init__(**init_params)
-
-        if run_check:
-            self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
-            )
+        self.__init__(
+            **init_params,
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
+        )
 
     @classmethod
     @copy_replace_short_description(read_skyh5, style=DocstringStyle.NUMPYDOC)
@@ -3912,12 +3919,10 @@ class SkyModel(UVBase):
             stokes_error=stokes_error,
             history=history,
             filename=os.path.basename(votable_file),
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
         )
-
-        if run_check:
-            self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
-            )
 
         return
 
@@ -4079,12 +4084,10 @@ class SkyModel(UVBase):
             reference_frequency=reference_frequency,
             spectral_index_column=spectral_index_column,
             flux_error_columns=flux_error_columns,
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
         )
-
-        if run_check:
-            self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
-            )
 
         return
 
@@ -4292,12 +4295,10 @@ class SkyModel(UVBase):
             spectral_index=spectral_index,
             stokes_error=stokes_error,
             filename=os.path.basename(catalog_csv),
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
         )
-
-        if run_check:
-            self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
-            )
 
         return
 
@@ -4467,12 +4468,10 @@ class SkyModel(UVBase):
             beam_amp=beam_amp,
             extended_model_group=extended_model_group,
             filename=os.path.basename(filename_sav),
+            run_check=run_check,
+            check_extra=check_extra,
+            run_check_acceptability=run_check_acceptability,
         )
-
-        if run_check:
-            self.check(
-                check_extra=check_extra, run_check_acceptability=run_check_acceptability
-            )
 
         return
 

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -3168,8 +3168,6 @@ class SkyModel(UVBase):
 
         if non_negative:
             non_neg_inds = np.nonzero(~np.any(skyobj.stokes[0] < 0, axis=0))[0]
-            if np.any(skyobj.stokes[0, :, :] < 0):
-                assert non_neg_inds.size < skyobj.Ncomponents
             if component_inds is not None:
                 component_inds = np.intersect1d(component_inds, non_neg_inds)
             else:

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -1275,6 +1275,18 @@ class SkyModel(UVBase):
                 "reference_frequency must have a unit that can be converted to Hz."
             )
 
+        if run_check_acceptability:
+            if self.spectral_type == "spectral_index" and np.any(
+                np.isnan(self.spectral_index)
+            ):
+                warnings.warn("Some spectral index values are NaNs.")
+
+            if np.any(np.isnan(self.stokes)):
+                warnings.warn("Some stokes values are NaNs.")
+
+            if np.any(self.stokes[0, :, :] < 0):
+                warnings.warn("Some stokes I values are negative.")
+
         return True
 
     def __eq__(
@@ -2092,6 +2104,8 @@ class SkyModel(UVBase):
             atol = self.freq_tol
 
         if self.spectral_type == "spectral_index":
+            if np.any(np.isnan(self.spectral_index)):
+                raise ValueError("Some spectral index values are NaNs.")
             sky.stokes = (
                 self.stokes
                 * (freqs[:, None].to("Hz") / self.reference_frequency[None, :].to("Hz"))

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -2361,6 +2361,7 @@ def test_select_flux(spec_type, init_kwargs, cut_kwargs, cut_type):
         min_brightness=minI_cut,
         max_brightness=maxI_cut,
         brightness_freq_range=freq_range,
+        non_nan=None,
     )
 
     if (

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -2179,10 +2179,14 @@ def test_cut_nan_neg():
     ):
         skyobj.check()
 
-    skyobj2 = skyobj.select(non_nan=True, non_negative=True, inplace=False)
+    with check_warnings(UserWarning, match=["Some stokes I values are negative"]):
+        skyobj.select(non_nan=True, inplace=False)
+
+    with check_warnings(UserWarning, match=["Some stokes values are NaNs."]):
+        skyobj.select(non_negative=True, inplace=False)
 
     with check_warnings(None):
-        skyobj2.check()
+        skyobj2 = skyobj.select(non_nan=True, non_negative=True, inplace=False)
 
     assert skyobj2.Ncomponents == 29
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,6 +73,9 @@ def test_stokes_tofrom_coherency():
     )
 
 
+@pytest.mark.filterwarnings("ignore:Some stokes I values are negative")
+@pytest.mark.filterwarnings("ignore:Some spectral index values are NaN")
+@pytest.mark.filterwarnings("ignore:Some stokes values are NaNs")
 @pytest.mark.parametrize("stype", ["subband", "spectral_index", "flat"])
 def test_download_gleam(tmp_path, stype, capsys):
     pytest.importorskip("astroquery")
@@ -149,6 +152,7 @@ def test_jy_to_ksr():
     assert np.allclose(conv0, conv1)
 
 
+@pytest.mark.filterwarnings("ignore:Some stokes I values are negative")
 @pytest.mark.parametrize(
     ("fspec", "use_cli"), [("freqs", True), ("freqs", False), ("redshifts", False)]
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds two new options to select:
- `non_nan` to select components that do not have NaN values in the `stokes` parameter at either any or all frequencies.
- `non-negative` to select components with non-negative Stokes I values (negative Stokes Q, U and V are meaningful)

These are helpful for GLEAM, which has both of these issues. I updated the tutorial section on reading in GLEAM with more information about these issues and the spectral types.

I also added some warnings to the `check` method to inform users if these issues are present in their SkyModel object. These only happen if `run_check_acceptibility` is True (which is the default).

I also discovered that on file reads we were calling the `__init__` method but not passing the checking options through to `__init__`, which always ran check. So we were typically re-running check 2-3 times, and there was no way to actually turn off checking on read, which I consider to be a bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This is need to address an issue in pyuvsim where the reference sims have had to use a flat spectral type with Gleam to avoid issues with NaNs and negative Stokes I values.

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).

### New Feature Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
