### PR TITLE
Provide better error messages when reading VOT files with generic read

### DIFF
--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -4742,13 +4742,25 @@ class SkyModel(UVBase):
                 run_check_acceptability=run_check_acceptability,
             )
         elif filetype == "vot":
+            required_params = {
+                "table_name": table_name,
+                "id_column": id_column,
+                "lon_column": lon_column,
+                "lat_column": lat_column,
+                "flux_columns": flux_columns,
+                "frame": frame,
+            }
+            for name, val in required_params.items():
+                if val is None:
+                    raise ValueError(f"{name} is required when reading vot files.")
+
             self.read_votable_catalog(
                 filename,
-                table_name,
-                id_column,
-                lon_column,
-                lat_column,
-                flux_columns,
+                table_name=table_name,
+                id_column=id_column,
+                lon_column=lon_column,
+                lat_column=lat_column,
+                flux_columns=flux_columns,
                 frame=frame,
                 reference_frequency=reference_frequency,
                 freq_array=freq_array,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provide useful error messages when required parameters are not passed for generic reads of VOT files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #200 

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [x] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
