### PR TITLE
fix warnings about default channel on CI runs that use conda

### DIFF
--- a/.github/workflows/externaltests.yaml
+++ b/.github/workflows/externaltests.yaml
@@ -35,6 +35,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ../pyuvsim/ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -29,6 +29,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -34,6 +34,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |
@@ -90,6 +91,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |
@@ -143,6 +145,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |
@@ -239,6 +242,7 @@ jobs:
             python-version: ${{ env.PYTHON }}
             environment-file: ci/${{ env.ENV_NAME }}.yaml
             activate-environment: ${{ env.ENV_NAME }}
+            conda-remove-defaults: "true"
 
         - name: Conda Info
           run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure that conda "defaults" channel is not used. Note that even with this fix there are still some warnings about this but they seem to be unavoidable and the number of warnings is now reduced.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Build/CI Change Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme
