### PR TITLE
Remove TEE/CIRS conversion funcs now that astropy has TETE

### DIFF
--- a/src/pyradiosky/utils.py
+++ b/src/pyradiosky/utils.py
@@ -5,76 +5,13 @@
 import os
 
 import astropy.units as units
-import erfa
 import numpy as np
-from astropy.coordinates import Angle
-from astropy.coordinates.builtin_frames.utils import get_jd12
 from astropy.cosmology import Planck15
-from astropy.time import Time
 from astropy.units import Quantity
 
 from pyradiosky.data import DATA_PATH as SKY_DATA_PATH
 
 f21 = 1.420405751e9
-
-
-# The frame radio astronomers call the apparent or current epoch is the
-# "true equator & equinox" frame, notated E_upsilon in the USNO circular
-# astropy doesn't have this frame but it's pretty easy to adapt the CIRS frame
-# by modifying the ra to reflect the difference between
-# GAST (Grenwich Apparent Sidereal Time) and the earth rotation angle (theta)
-def _tee_to_cirs_ra(tee_ra, time):
-    """
-    Convert from the true equator & equinox frame to the CIRS frame.
-
-    The frame radio astronomers call the apparent or current epoch is the
-    "true equator & equinox" frame, notated E_upsilon in the USNO circular
-    astropy doesn't have this frame but it's pretty easy to adapt the CIRS frame
-    by modifying the ra to reflect the difference between
-    GAST (Grenwich Apparent Sidereal Time) and the earth rotation angle (theta)
-
-    Parameters
-    ----------
-    tee_ra : :class:`astropy.Angle`
-        Current epoch RA (RA in the true equator and equinox frame).
-    time : :class:`astropy.Time`
-        Time object for the epoch of the `tee_ra`.
-    """
-    era = erfa.era00(*get_jd12(time, "ut1"))
-    theta_earth = Angle(era, unit="rad")
-
-    assert isinstance(time, Time)
-    assert isinstance(tee_ra, Angle)
-    gast = time.sidereal_time("apparent", longitude=0)
-    cirs_ra = tee_ra - (gast - theta_earth)
-    return cirs_ra
-
-
-def _cirs_to_tee_ra(cirs_ra, time):
-    """
-    Convert from CIRS frame to the true equator & equinox frame.
-
-    The frame radio astronomers call the apparent or current epoch is the
-    "true equator & equinox" frame, notated E_upsilon in the USNO circular
-    astropy doesn't have this frame but it's pretty easy to adapt the CIRS frame
-    by modifying the ra to reflect the difference between
-    GAST (Grenwich Apparent Sidereal Time) and the earth rotation angle (theta)
-
-    Parameters
-    ----------
-    cirs_ra : :class:`astropy.Angle`
-        CIRS RA.
-    time : :class:`astropy.Time`
-        Time object for time to convert to the "true equator & equinox" frame.
-    """
-    era = erfa.era00(*get_jd12(time, "ut1"))
-    theta_earth = Angle(era, unit="rad")
-
-    assert isinstance(time, Time)
-    assert isinstance(cirs_ra, Angle)
-    gast = time.sidereal_time("apparent", longitude=0)
-    tee_ra = cirs_ra + (gast - theta_earth)
-    return tee_ra
 
 
 def stokes_to_coherency(stokes_arr):

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -482,24 +482,31 @@ def test_check_errors():
         skyobj2.check()
 
 
-def test_source_zenith_from_icrs(time_location):
-    """Test single source position at zenith constructed using icrs."""
+def test_source_zenith_from_tete(time_location):
+    """
+    Test single source position at zenith constructed using TETE frame.
+
+    The frame radio astronomers call the apparent or current epoch is the
+    "true equator & equinox" frame, notated E_upsilon in the USNO circular
+    astropy calls this the TETE frame (true equinox and true equator).
+
+    Zenith should be given by the apparent LST and the telescope latitude in
+    this frame.
+
+    """
     time, array_location = time_location
 
     lst = time.sidereal_time("apparent")
 
-    tee_ra = lst
-    cirs_ra = skyutils._tee_to_cirs_ra(tee_ra, time)
-
-    cirs_source_coord = SkyCoord(
-        ra=cirs_ra,
+    tete_cood = SkyCoord(
+        ra=lst,
         dec=array_location.lat,
         obstime=time,
-        frame="cirs",
+        frame="tete",
         location=array_location,
     )
 
-    icrs_coord = cirs_source_coord.transform_to("icrs")
+    icrs_coord = tete_cood.transform_to("icrs")
 
     zenith_source = SkyModel(
         name="icrs_zen",
@@ -511,7 +518,8 @@ def test_source_zenith_from_icrs(time_location):
 
     zenith_source.update_positions(time, array_location)
     zenith_source_lmn = zenith_source.pos_lmn.squeeze()
-    assert np.allclose(zenith_source_lmn, np.array([0, 0, 1]), atol=1e-5)
+    # not sure why it's not better precision than this:
+    np.testing.assert_allclose(zenith_source_lmn, np.array([0, 0, 1]), atol=1e-6)
 
 
 def test_source_zenith(time_location, zenith_skymodel):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,19 +6,9 @@ import subprocess  # nosec
 import astropy.units as units
 import numpy as np
 import pytest
-from astropy.coordinates import Angle
 from astropy.cosmology import Planck15
-from astropy.time import Time
 
 from pyradiosky import SkyModel, utils as skyutils
-
-
-def test_tee_ra_loop():
-    time = Time(2457458.1739, scale="utc", format="jd")
-    tee_ra = Angle(np.pi / 4.0, unit="rad")  # rad
-    cirs_ra = skyutils._tee_to_cirs_ra(tee_ra, time)
-    new_tee_ra = skyutils._cirs_to_tee_ra(cirs_ra, time)
-    assert new_tee_ra == tee_ra
 
 
 def test_stokes_tofrom_coherency():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We had some functions to enable testing setting up a SkyModel object with a source at zenith based on the apparent LST and telescope declination, which required some code to convert from the True Equator & Equinox frame because astropy didn't have that frame in the past. That frame is now available (called TETE, added in astropy v4.2) so this code is no longer needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [ ] Any new or updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate).
- [ ] I have added tests to cover any changes.
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
