### PR TITLE
Fix handling of extended_model_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## [Unreleased]
 
 ### Changed
+- If no extended models remain after a select, the `extended_model_group` parameter
+is set to `None` after the select.
 - Updated minimum optional dependency versions: lunarsky>=1.0 (to drop spiceypy requirement)
+
+### Fixed
+- A bug where the `extended_model_group` was set to an array of empty strings
+when reading in FHD catalogs with no extended models.
 
 ### Removed
 - Spiceypy error catching in tests

--- a/src/pyradiosky/skymodel.py
+++ b/src/pyradiosky/skymodel.py
@@ -3265,6 +3265,13 @@ class SkyModel(UVBase):
 
         skyobj._select_along_param_axis({"Ncomponents": component_inds})
 
+        # if all extended models were removed in select, set extended_model_group
+        # to None
+        if skyobj.extended_model_group is not None:
+            extended_comps = np.nonzero(skyobj.extended_model_group != "")[0]
+            if extended_comps.size == 0:
+                skyobj.extended_model_group = None
+
         if run_check:
             skyobj.check(
                 check_extra=check_extra, run_check_acceptability=run_check_acceptability
@@ -4440,7 +4447,6 @@ class SkyModel(UVBase):
             downselecting data on this object (the default is True, meaning the
             acceptable range check will be done).
 
-
         """
         catalog = scipy.io.readsav(filename_sav)
         if "catalog" in catalog:
@@ -4577,6 +4583,10 @@ class SkyModel(UVBase):
                         source_freqs, use_index, src["freq"] * 1e6 * units.Hz
                     )
                     spectral_index = np.insert(spectral_index, use_index, src["alpha"])
+            else:
+                extended_model_group = None
+        else:
+            extended_model_group = None
 
         if len(extra_col_dict) == 0:
             extra_col_dict = None

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -2281,6 +2281,7 @@ def test_select(time_location):
     skyobj.select(component_inds=np.arange(10), run_check=False)
 
     assert skyobj == skyobj2
+    assert skyobj.extended_model_group is None
 
 
 @pytest.mark.filterwarnings("ignore:Some Stokes I values are negative")
@@ -3126,6 +3127,11 @@ def test_fhd_catalog_reader_extended_sources(extended):
     ext_Ncomps = [len(catalog[ext]["extend"]) for ext in ext_inds]
     assert skyobj.Ncomponents == len(catalog) - len(ext_inds) + sum(ext_Ncomps)
 
+    if not extended:
+        assert skyobj.extended_model_group is None
+    else:
+        assert skyobj.extended_model_group is not None
+
 
 def test_fhd_catalog_reader_beam_values():
     catfile = os.path.join(SKY_DATA_PATH, "fhd_catalog_with_beam_values.sav")
@@ -3141,6 +3147,8 @@ def test_fhd_catalog_reader_beam_values():
     beam_vals = beam_vals[:, np.newaxis, :]
 
     assert np.min(np.abs(skyobj.beam_amp - beam_vals)) == 0
+
+    assert skyobj.extended_model_group is None
 
 
 def test_fhd_catalog_reader_beam_values_extended():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Currently, when reading in FHD catalogs with no extended models, the `extended_model_group` is set to an array of empty strings rather than `None`. This fixes that.

It also sets the `extended_model_group` to `None` after selection if no extended models remain after the selection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Bug Fix Checklist:
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md).
