### PR TITLE
Require lunarsky>1.0 to remove spiceypy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- Updated minimum optional dependency versions: lunarsky>=1.0 (to drop spiceypy requirement)
+
+### Removed
+- Spiceypy error catching in tests
+
 ## [1.1.1] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Optional:
 
 * astropy-healpix>=1.0.2 (for working with beams in HEALPix formats)
 * astroquery>=0.4.4 (for downloading GLEAM and other VizieR catalogs)
-* lunarsky>=0.2.5 (for supporting telescope locations on the moon)
+* lunarsky>=1.0 (for supporting telescope locations on the moon)
 
 We suggest using conda to install all the dependencies. To install
 pyuvdata, astropy-healpix and astroquery, you'll need to add conda-forge as a channel

--- a/ci/full_deps.yaml
+++ b/ci/full_deps.yaml
@@ -15,4 +15,4 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - pip:
-      - lunarsky>=0.2.5
+      - lunarsky>=1.0

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -14,4 +14,4 @@ dependencies:
   - pyuvdata==3.2.3
   - pip
   - pip:
-      - lunarsky==0.2.5
+      - lunarsky==1.0.1.post2

--- a/environment.yaml
+++ b/environment.yaml
@@ -18,4 +18,4 @@ dependencies:
   - setuptools_scm>=8.1
   - sphinx
   - pip:
-      - lunarsky>=0.2.5
+      - lunarsky>=1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 [project.optional-dependencies]
 healpix = ["astropy-healpix>=1.0.2"]
 astroquery = ["astroquery>=0.4.4"]
-lunarsky = ["lunarsky>=0.2.5"]
+lunarsky = ["lunarsky>=1.0"]
 all = ["pyradiosky[healpix,astroquery,lunarsky]"]
 test = ["coverage", "pre-commit", "pytest", "pytest-cov"]
 doc = ["matplotlib", "pypandoc", "sphinx"]

--- a/tests/test_skymodel.py
+++ b/tests/test_skymodel.py
@@ -85,7 +85,6 @@ def moonsky():
     pytest.importorskip("lunarsky")
 
     from lunarsky import MoonLocation, SkyCoord as LunarSkyCoord
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
 
     # Tranquility base
     array_location = MoonLocation(lat="00d41m15s", lon="23d26m00s", height=0.0)
@@ -106,10 +105,7 @@ def moonsky():
     zenith_source = SkyModel(
         name=names, skycoord=icrs_coord, stokes=stokes, spectral_type="flat"
     )
-    try:
-        zenith_source.update_positions(time, array_location)
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    zenith_source.update_positions(time, array_location)
 
     yield zenith_source
 
@@ -1260,8 +1256,6 @@ def test_calc_basis_rotation_matrix(time_location, moon_time_location, telescope
     This tests whether the 3-D rotation matrix from RA/Dec to Alt/Az is
     actually a rotation matrix (R R^T = R^T R = I)
     """
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
-
     if telescope_frame == "itrs":
         time, telescope_location = time_location
     else:
@@ -1276,11 +1270,8 @@ def test_calc_basis_rotation_matrix(time_location, moon_time_location, telescope
         spectral_type="flat",
     )
 
-    try:
-        source.update_positions(time, telescope_location)
-        basis_rot_matrix = source._calc_average_rotation_matrix()
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    source.update_positions(time, telescope_location)
+    basis_rot_matrix = source._calc_average_rotation_matrix()
 
     assert np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T), np.eye(3))
     assert np.allclose(np.matmul(basis_rot_matrix.T, basis_rot_matrix), np.eye(3))
@@ -1292,8 +1283,6 @@ def test_calc_vector_rotation(time_location, moon_time_location, telescope_frame
     This checks that the 2-D coherency rotation matrix is unit determinant.
     I suppose we could also have checked (R R^T = R^T R = I)
     """
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
-
     if telescope_frame == "itrs":
         time, telescope_location = time_location
     else:
@@ -1309,10 +1298,7 @@ def test_calc_vector_rotation(time_location, moon_time_location, telescope_frame
     )
     source.update_positions(time, telescope_location)
 
-    try:
-        coherency_rotation = np.squeeze(source._calc_coherency_rotation())
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    coherency_rotation = np.squeeze(source._calc_coherency_rotation())
 
     assert np.isclose(np.linalg.det(coherency_rotation), 1)
 
@@ -3525,8 +3511,6 @@ def test_zenith_on_moon(moonsky):
 def test_source_motion(moonsky):
     """Check that period is about 28 days."""
 
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
-
     zenith_source = moonsky
 
     Ntimes = 500
@@ -3534,12 +3518,9 @@ def test_source_motion(moonsky):
     times = zenith_source.time + TimeDelta(ets, format="sec")
 
     lmns = np.zeros((Ntimes, 3))
-    try:
-        for ti in range(Ntimes):
-            zenith_source.update_positions(times[ti], zenith_source.telescope_location)
-            lmns[ti] = zenith_source.pos_lmn.squeeze()
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    for ti in range(Ntimes):
+        zenith_source.update_positions(times[ti], zenith_source.telescope_location)
+        lmns[ti] = zenith_source.pos_lmn.squeeze()
     _els = np.fft.fft(lmns[:, 0])
     dt = np.diff(ets)[0]
     _freqs = np.fft.fftfreq(Ntimes, d=dt)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The latest version of lunarsky drops the dependency on spiceypy and has some accuracy improvement. This bumps the minimum version of lunarsky. And removes the try blocks that catch SPICEUnknownFrameErrors in unit tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Checklists:
<!--- Please remove the checklists that don't apply to your change type(s)-->

### Other Change Checklist
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/.github/CONTRIBUTING.md).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/blob/main/CHANGELOG.md) if appropriate.
